### PR TITLE
Proc macros for rules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 clap = "4.3.17"
 derive_builder = "0.12.0"
+proc_macros = { path = "proc_macros" }
 regex = "1.9.1"
 tree-sitter = "0.20.10"
 tree-sitter-grep = { git = "https://github.com/helixbass/tree-sitter-grep", rev = "3d4682c" }

--- a/proc_macros/.gitignore
+++ b/proc_macros/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/proc_macros/Cargo.toml
+++ b/proc_macros/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "proc_macros"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+proc-macro2 = "1.0.66"
+quote = "1.0.31"
+syn = "2.0.26"
+
+[lib]
+proc-macro = true

--- a/proc_macros/src/lib.rs
+++ b/proc_macros/src/lib.rs
@@ -1,0 +1,46 @@
+use std::collections::HashMap;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_macro_input, Expr, ExprPath, Ident, Token,
+};
+
+struct BuilderArgs {
+    builder_name: ExprPath,
+    args: HashMap<Ident, Expr>,
+}
+
+impl Parse for BuilderArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let builder_name: ExprPath = input.parse()?;
+        input.parse::<Token![,]>()?;
+        let mut args: HashMap<Ident, Expr> = Default::default();
+        while !input.is_empty() {
+            let key: Ident = input.parse()?;
+            input.parse::<Token![=>]>()?;
+            let value: Expr = input.parse()?;
+            if !input.is_empty() {
+                input.parse::<Token![,]>()?;
+            }
+            args.insert(key, value);
+        }
+        Ok(BuilderArgs { builder_name, args })
+    }
+}
+
+#[proc_macro]
+pub fn builder_args(input: TokenStream) -> TokenStream {
+    let BuilderArgs { builder_name, args } = parse_macro_input!(input as BuilderArgs);
+
+    let keys = args.keys();
+    let values = args.values();
+    quote! {
+        #builder_name::default()
+            #(.#keys(#values))*
+            .build()
+            .unwrap()
+    }
+    .into()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,12 +117,12 @@ fn get_rules() -> Vec<Rule> {
 }
 
 fn no_default_default_rule() -> Rule {
-    RuleBuilder::default()
-        .name("no_default_default")
-        .create(|_context| {
-            vec![RuleListenerBuilder::default()
-                .query(
-                    r#"(
+    rule! {
+        name => "no_default_default",
+        create => |_context| {
+            vec![
+                rule_listener! {
+                    query => r#"(
                       (call_expression
                         function:
                           (scoped_identifier
@@ -133,22 +133,20 @@ fn no_default_default_rule() -> Rule {
                           )
                       ) @c
                     )"#,
-                )
-                .capture_name("c")
-                .on_query_match(|node, query_match_context| {
-                    query_match_context.report(
-                        ViolationBuilder::default()
-                            .message(r#"Use '_d()' instead of 'Default::default()'"#)
-                            .node(node)
-                            .build()
-                            .unwrap(),
-                    );
-                })
-                .build()
-                .unwrap()]
-        })
-        .build()
-        .unwrap()
+                    capture_name => "c",
+                    on_query_match => |node, query_match_context| {
+                        query_match_context.report(
+                            ViolationBuilder::default()
+                                .message(r#"Use '_d()' instead of 'Default::default()'"#)
+                                .node(node)
+                                .build()
+                                .unwrap(),
+                        );
+                    }
+                }
+            ]
+        }
+    }
 }
 
 fn no_lazy_static_rule() -> Rule {

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -37,6 +37,16 @@ impl RuleBuilder {
     }
 }
 
+#[macro_export]
+macro_rules! rule {
+    ($($variant:ident => $value:expr),* $(,)?) => {
+        proc_macros::builder_args!(
+            $crate::rule::RuleBuilder,
+            $($variant => $value),*,
+        )
+    }
+}
+
 pub struct ResolvedRule<'context> {
     pub name: String,
     pub listeners: Vec<ResolvedRuleListener<'context>>,
@@ -89,6 +99,16 @@ impl<'on_query_match> RuleListenerBuilder<'on_query_match> {
     ) -> &mut Self {
         self.on_query_match = Some(Arc::new(callback));
         self
+    }
+}
+
+#[macro_export]
+macro_rules! rule_listener {
+    ($($variant:ident => $value:expr),* $(,)?) => {
+        proc_macros::builder_args!(
+            $crate::rule::RuleListenerBuilder,
+            $($variant => $value),*,
+        )
     }
 }
 


### PR DESCRIPTION
In this PR:
- per comment on previous PR, add a macro syntax for specifying rules

To test:
Per the one hard-coded rule that is now using the macro syntax, you should be able to use the `key => value` notation for anything that would flow through to an argument on the underlying builder (for the `Rule`/`RuleListener`)

Based on `rule`