### PR TITLE
More complicated rule + basic rule-testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,8 @@ tree-sitter-rust = "0.20.3"
 
 [[bin]]
 name = "tree-sitter-lint"
+
+[dev-dependencies]
+assert_cmd = "2.0.12"
+predicates = "3.0.3"
+tempdir = "0.3.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,9 @@ regex = "1.9.1"
 tree-sitter = "0.20.10"
 tree-sitter-grep = { git = "https://github.com/helixbass/tree-sitter-grep", rev = "3d4682c" }
 tree-sitter-rust = "0.20.3"
-
-[[bin]]
-name = "tree-sitter-lint"
-
-[dev-dependencies]
 assert_cmd = "2.0.12"
 predicates = "3.0.3"
 tempdir = "0.3.7"
+
+[[bin]]
+name = "tree-sitter-lint"

--- a/proc_macros/src/lib.rs
+++ b/proc_macros/src/lib.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 
 use proc_macro::TokenStream;
-use quote::quote;
+use quote::{quote, ToTokens};
 use syn::{
+    braced, bracketed,
     parse::{Parse, ParseStream},
-    parse_macro_input, Expr, ExprPath, Ident, Token,
+    parse_macro_input, Expr, ExprArray, ExprPath, Ident, Token,
 };
 
 struct BuilderArgs {
@@ -41,6 +42,111 @@ pub fn builder_args(input: TokenStream) -> TokenStream {
             #(.#keys(#values))*
             .build()
             .unwrap()
+    }
+    .into()
+}
+
+struct InvalidRuleTestSpec {
+    code: Expr,
+    errors: ExprArray,
+}
+
+impl Parse for InvalidRuleTestSpec {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut code: Option<Expr> = Default::default();
+        let mut errors: Option<ExprArray> = Default::default();
+        let content;
+        braced!(content in input);
+        while !content.is_empty() {
+            let key: Ident = content.parse()?;
+            content.parse::<Token![=>]>()?;
+            match &*key.to_string() {
+                "code" => {
+                    code = Some(content.parse()?);
+                }
+                "errors" => {
+                    errors = Some(content.parse()?);
+                }
+                _ => panic!("didn't expect key {}", key),
+            }
+            if !content.is_empty() {
+                content.parse::<Token![,]>()?;
+            }
+        }
+        Ok(Self {
+            code: code.expect("Expected 'code'"),
+            errors: errors.expect("Expected 'errors'"),
+        })
+    }
+}
+
+impl ToTokens for InvalidRuleTestSpec {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let code = &self.code;
+        let errors = &self.errors;
+        quote! {
+            crate::rule_tester::RuleTestInvalid::new(
+                #code,
+                #errors
+            )
+        }
+        .to_tokens(tokens)
+    }
+}
+
+struct RuleTests {
+    valid: ExprArray,
+    invalid: Vec<InvalidRuleTestSpec>,
+}
+
+impl Parse for RuleTests {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut valid: Option<ExprArray> = Default::default();
+        let mut invalid: Option<Vec<InvalidRuleTestSpec>> = Default::default();
+        while !input.is_empty() {
+            let key: Ident = input.parse()?;
+            input.parse::<Token![=>]>()?;
+            match &*key.to_string() {
+                "valid" => {
+                    assert!(valid.is_none(), "Already saw 'valid' key");
+                    valid = Some(input.parse()?);
+                }
+                "invalid" => {
+                    assert!(invalid.is_none(), "Already saw 'invalid' key");
+                    let invalid_content;
+                    bracketed!(invalid_content in input);
+                    let invalid = invalid.get_or_insert_with(|| Default::default());
+                    while !invalid_content.is_empty() {
+                        let invalid_rule_test_spec: InvalidRuleTestSpec =
+                            invalid_content.parse()?;
+                        invalid.push(invalid_rule_test_spec);
+                        if !invalid_content.is_empty() {
+                            invalid_content.parse::<Token![,]>()?;
+                        }
+                    }
+                }
+                _ => panic!("didn't expect key {}", key),
+            }
+            if !input.is_empty() {
+                input.parse::<Token![,]>()?;
+            }
+        }
+        Ok(Self {
+            valid: valid.expect("Expected 'valid'"),
+            invalid: invalid.expect("Expected 'invalid'"),
+        })
+    }
+}
+
+#[proc_macro]
+pub fn rule_tests(input: TokenStream) -> TokenStream {
+    let RuleTests { valid, invalid } = parse_macro_input!(input);
+
+    quote! {
+        crate::rule_tester::RuleTests::new(
+            #valid,
+            vec![#(#invalid),*],
+        )
     }
     .into()
 }

--- a/proc_macros/src/lib.rs
+++ b/proc_macros/src/lib.rs
@@ -85,7 +85,7 @@ impl ToTokens for InvalidRuleTestSpec {
         let code = &self.code;
         let errors = &self.errors;
         quote! {
-            crate::rule_tester::RuleTestInvalid::new(
+            tree_sitter_lint::RuleTestInvalid::new(
                 #code,
                 #errors
             )
@@ -143,7 +143,7 @@ pub fn rule_tests(input: TokenStream) -> TokenStream {
     let RuleTests { valid, invalid } = parse_macro_input!(input);
 
     quote! {
-        crate::rule_tester::RuleTests::new(
+        tree_sitter_lint::RuleTests::new(
             #valid,
             vec![#(#invalid),*],
         )

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,4 +1,7 @@
 use clap::Parser;
 
 #[derive(Parser)]
-pub struct Args {}
+pub struct Args {
+    #[arg(long)]
+    pub rule: Option<String>,
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -70,6 +70,18 @@ impl<'a> QueryMatchContext<'a> {
         }
         Some(first_node)
     }
+
+    pub fn get_number_of_query_matches<'query, 'enclosing_node>(
+        &self,
+        query: impl Into<ParsedOrUnparsedQuery<'query>>,
+        enclosing_node: Node<'enclosing_node>,
+    ) -> usize {
+        let query = query.into().into_parsed(self.context.language);
+        let mut query_cursor = QueryCursor::new();
+        query_cursor
+            .matches(&query, enclosing_node, self.file_contents)
+            .count()
+    }
 }
 
 pub enum ParsedOrUnparsedQuery<'query_text> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,7 +3,7 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
-use tree_sitter::Language;
+use tree_sitter::{Language, Node, Query, QueryCursor};
 
 use crate::{rule::ResolvedRule, violation::Violation};
 
@@ -22,6 +22,7 @@ pub struct QueryMatchContext<'a> {
     pub file_contents: &'a [u8],
     pub rule: &'a ResolvedRule<'a>,
     reported_any_violations: &'a AtomicBool,
+    context: &'a Context,
 }
 
 impl<'a> QueryMatchContext<'a> {
@@ -30,18 +31,70 @@ impl<'a> QueryMatchContext<'a> {
         file_contents: &'a [u8],
         rule: &'a ResolvedRule,
         reported_any_violations: &'a AtomicBool,
+        context: &'a Context,
     ) -> Self {
         Self {
             path,
             file_contents,
             rule,
             reported_any_violations,
+            context,
         }
     }
 
     pub fn report(&self, violation: Violation) {
         self.reported_any_violations.store(true, Ordering::Relaxed);
         print_violation(&violation, self);
+    }
+
+    pub fn get_node_text(&self, node: Node) -> &str {
+        node.utf8_text(self.file_contents).unwrap()
+    }
+
+    pub fn maybe_get_single_matching_node_for_query<'query, 'enclosing_node>(
+        &self,
+        query: impl Into<ParsedOrUnparsedQuery<'query>>,
+        enclosing_node: Node<'enclosing_node>,
+    ) -> Option<Node<'enclosing_node>> {
+        let query = query.into().into_parsed(self.context.language);
+        let mut query_cursor = QueryCursor::new();
+        let mut matches = query_cursor.matches(&query, enclosing_node, self.file_contents);
+        let first_match = matches.next()?;
+        if matches.next().is_some() {
+            return None;
+        }
+        let mut nodes_for_default_capture_index = first_match.nodes_for_capture_index(0);
+        let first_node = nodes_for_default_capture_index.next()?;
+        if nodes_for_default_capture_index.next().is_some() {
+            return None;
+        }
+        Some(first_node)
+    }
+}
+
+pub enum ParsedOrUnparsedQuery<'query_text> {
+    Parsed(Query),
+    Unparsed(&'query_text str),
+}
+
+impl<'query_text> ParsedOrUnparsedQuery<'query_text> {
+    pub fn into_parsed(self, language: Language) -> Query {
+        match self {
+            Self::Parsed(query) => query,
+            Self::Unparsed(query_text) => Query::new(language, query_text).unwrap(),
+        }
+    }
+}
+
+impl<'query_text> From<Query> for ParsedOrUnparsedQuery<'query_text> {
+    fn from(value: Query) -> Self {
+        Self::Parsed(value)
+    }
+}
+
+impl<'query_text> From<&'query_text str> for ParsedOrUnparsedQuery<'query_text> {
+    fn from(value: &'query_text str) -> Self {
+        Self::Unparsed(value)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,37 +242,35 @@ macro_rules! return_if_none {
 }
 
 fn prefer_impl_param_rule() -> Rule {
-    RuleBuilder::default()
-        .name("prefer_impl_param")
-        .create(|_context| {
-            vec![RuleListenerBuilder::default()
-                .query(
-                    r#"(
+    rule! {
+        name => "prefer_impl_param",
+        create => |_context| {
+            vec![
+                rule_listener! {
+                    query => r#"(
                       (type_parameters
                           (constrained_type_parameter) @c
                       )
                     )"#,
-                )
-                .on_query_match(|node, query_match_context| {
-                    let type_parameter_name = query_match_context.get_node_text(get_constrained_type_parameter_name(node));
-                    let single_type_parameter_usage_node = return_if_none!(query_match_context.maybe_get_single_matching_node_for_query(
-                        &*format!(
-                          r#"(
-                            (type_identifier) @type_parameter_usage (#eq? @type_parameter_usage "{type_parameter_name}"))"#
-                        ),
-                        get_parameters_node_of_enclosing_function(node)
-                    ));
-                    query_match_context.report(
-                        ViolationBuilder::default()
-                            .message(r#"Prefer using 'param: impl Trait'"#)
-                            .node(single_type_parameter_usage_node)
-                            .build()
-                            .unwrap(),
-                    );
-                })
-                .build()
-                .unwrap()]
-        })
-        .build()
-        .unwrap()
+                    on_query_match => |node, query_match_context| {
+                        let type_parameter_name = query_match_context.get_node_text(get_constrained_type_parameter_name(node));
+                        let single_type_parameter_usage_node = return_if_none!(query_match_context.maybe_get_single_matching_node_for_query(
+                            &*format!(
+                              r#"(
+                                (type_identifier) @type_parameter_usage (#eq? @type_parameter_usage "{type_parameter_name}"))"#
+                            ),
+                            get_parameters_node_of_enclosing_function(node)
+                        ));
+                        query_match_context.report(
+                            ViolationBuilder::default()
+                                .message(r#"Prefer using 'param: impl Trait'"#)
+                                .node(single_type_parameter_usage_node)
+                                .build()
+                                .unwrap(),
+                        );
+                    }
+                }
+            ]
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,7 +254,7 @@ fn prefer_impl_param_rule() -> Rule {
                     )"#,
                     on_query_match => |node, query_match_context| {
                         let type_parameter_name = query_match_context.get_node_text(get_constrained_type_parameter_name(node));
-                        let single_type_parameter_usage_node = return_if_none!(query_match_context.maybe_get_single_matching_node_for_query(
+                        return_if_none!(query_match_context.maybe_get_single_matching_node_for_query(
                             &*format!(
                               r#"(
                                 (type_identifier) @type_parameter_usage (#eq? @type_parameter_usage "{type_parameter_name}"))"#
@@ -264,7 +264,7 @@ fn prefer_impl_param_rule() -> Rule {
                         query_match_context.report(
                             ViolationBuilder::default()
                                 .message(r#"Prefer using 'param: impl Trait'"#)
-                                .node(single_type_parameter_usage_node)
+                                .node(node)
                                 .build()
                                 .unwrap(),
                         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,6 +298,9 @@ pub fn prefer_impl_param_rule() -> Rule {
                             get_parameters_node_of_enclosing_function(node)
                         ));
                         if let Some(return_type_node) = maybe_get_return_type_node_of_enclosing_function(node) {
+                            if return_type_node.kind() == "type_identifier" && query_match_context.get_node_text(return_type_node) == type_parameter_name {
+                                return;
+                            }
                             if query_match_context.get_number_of_query_matches(
                                 &*format!(
                                   r#"(

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -65,7 +65,7 @@ pub struct RuleListener<'on_query_match> {
     #[builder(default)]
     pub capture_name: Option<String>,
     #[builder(setter(custom))]
-    pub on_query_match: Arc<dyn Fn(&Node, &QueryMatchContext) + 'on_query_match + Send + Sync>,
+    pub on_query_match: Arc<dyn Fn(Node, &QueryMatchContext) + 'on_query_match + Send + Sync>,
 }
 
 impl<'on_query_match> RuleListener<'on_query_match> {
@@ -95,7 +95,7 @@ impl<'on_query_match> RuleListener<'on_query_match> {
 impl<'on_query_match> RuleListenerBuilder<'on_query_match> {
     pub fn on_query_match(
         &mut self,
-        callback: impl Fn(&Node, &QueryMatchContext) + 'on_query_match + Send + Sync,
+        callback: impl Fn(Node, &QueryMatchContext) + 'on_query_match + Send + Sync,
     ) -> &mut Self {
         self.on_query_match = Some(Arc::new(callback));
         self
@@ -116,5 +116,5 @@ pub struct ResolvedRuleListener<'on_query_match> {
     pub query: Query,
     pub query_text: String,
     pub capture_index: u32,
-    pub on_query_match: Arc<dyn Fn(&Node, &QueryMatchContext) + 'on_query_match + Send + Sync>,
+    pub on_query_match: Arc<dyn Fn(Node, &QueryMatchContext) + 'on_query_match + Send + Sync>,
 }

--- a/src/rule_tester.rs
+++ b/src/rule_tester.rs
@@ -4,7 +4,6 @@ use assert_cmd::prelude::*;
 use predicates::prelude::*;
 use tempdir::TempDir;
 
-#[cfg(test)]
 use crate::rule::Rule;
 
 pub struct RuleTester {

--- a/src/rule_tester.rs
+++ b/src/rule_tester.rs
@@ -1,0 +1,151 @@
+use std::{fs, process::Command};
+
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+use tempdir::TempDir;
+
+#[cfg(test)]
+use crate::rule::Rule;
+
+pub struct RuleTester {
+    rule: Rule,
+    rule_tests: RuleTests,
+}
+
+impl RuleTester {
+    fn new(rule: Rule, rule_tests: RuleTests) -> Self {
+        Self { rule, rule_tests }
+    }
+
+    pub fn run(rule: Rule, rule_tests: RuleTests) {
+        Self::new(rule, rule_tests).run_tests()
+    }
+
+    fn run_tests(&self) {
+        for valid_test in &self.rule_tests.valid_tests {
+            self.run_valid_test(valid_test);
+        }
+
+        for invalid_test in &self.rule_tests.invalid_tests {
+            self.run_invalid_test(invalid_test);
+        }
+    }
+
+    fn run_valid_test(&self, valid_test: &RuleTestValid) {
+        let tmp_dir = TempDir::new("valid_test").unwrap();
+        let test_filename = "tmp.rs";
+        fs::write(tmp_dir.path().join(test_filename), &valid_test.code).unwrap();
+        Command::cargo_bin("tree-sitter-lint")
+            .unwrap()
+            .args(["--rule", &self.rule.name])
+            .current_dir(tmp_dir.path())
+            .assert()
+            .success()
+            .stdout(predicate::str::is_empty());
+    }
+
+    fn run_invalid_test(&self, invalid_test: &RuleTestInvalid) {
+        let tmp_dir = TempDir::new("invalid_test").unwrap();
+        let test_filename = "tmp.rs";
+        fs::write(tmp_dir.path().join(test_filename), &invalid_test.code).unwrap();
+        Command::cargo_bin("tree-sitter-lint")
+            .unwrap()
+            .args(["--rule", &self.rule.name])
+            .current_dir(tmp_dir.path())
+            .assert()
+            .failure()
+            .code(1)
+            .stdout(predicate::function(|stdout: &str| {
+                does_invalid_output_match_expected(stdout, &invalid_test.errors)
+            }));
+    }
+}
+
+fn does_invalid_output_match_expected(
+    stdout: &str,
+    expected_errors: &[RuleTestExpectedError],
+) -> bool {
+    let mut lines: Vec<_> = stdout.split('\n').filter(|line| !line.is_empty()).collect();
+    if lines.len() != expected_errors.len() {
+        return false;
+    }
+    for expected_error in expected_errors {
+        match lines
+            .iter()
+            .position(|&line| line.contains(&expected_error.message))
+        {
+            None => return false,
+            Some(line_index) => {
+                lines.remove(line_index);
+            }
+        }
+    }
+    true
+}
+
+pub struct RuleTests {
+    valid_tests: Vec<RuleTestValid>,
+    invalid_tests: Vec<RuleTestInvalid>,
+}
+
+impl RuleTests {
+    pub fn new(
+        valid_tests: impl IntoIterator<Item = impl Into<RuleTestValid>>,
+        invalid_tests: Vec<RuleTestInvalid>,
+    ) -> Self {
+        Self {
+            valid_tests: valid_tests.into_iter().map(Into::into).collect(),
+            invalid_tests,
+        }
+    }
+}
+
+pub struct RuleTestValid {
+    code: String,
+}
+
+impl RuleTestValid {
+    pub fn new(code: impl Into<String>) -> Self {
+        Self { code: code.into() }
+    }
+}
+
+impl From<&str> for RuleTestValid {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+pub struct RuleTestInvalid {
+    code: String,
+    errors: Vec<RuleTestExpectedError>,
+}
+
+impl RuleTestInvalid {
+    pub fn new(
+        code: impl Into<String>,
+        errors: impl IntoIterator<Item = impl Into<RuleTestExpectedError>>,
+    ) -> Self {
+        Self {
+            code: code.into(),
+            errors: errors.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct RuleTestExpectedError {
+    pub message: String,
+}
+
+impl RuleTestExpectedError {
+    pub fn new(message: String) -> Self {
+        Self { message }
+    }
+}
+
+impl From<&str> for RuleTestExpectedError {
+    fn from(value: &str) -> Self {
+        Self::new(value.to_owned())
+    }
+}

--- a/src/violation.rs
+++ b/src/violation.rs
@@ -5,5 +5,5 @@ use tree_sitter::Node;
 #[builder(setter(into))]
 pub struct Violation<'a> {
     pub message: String,
-    pub node: &'a Node<'a>,
+    pub node: Node<'a>,
 }

--- a/tests/prefer_impl_param.rs
+++ b/tests/prefer_impl_param.rs
@@ -1,0 +1,55 @@
+use proc_macros::rule_tests;
+use tree_sitter_lint::{prefer_impl_param_rule, RuleTester};
+
+#[test]
+fn test_prefer_impl_param_rule() {
+    const ERROR_MESSAGE: &str = "Prefer using 'param: impl Trait'";
+
+    RuleTester::run(
+        prefer_impl_param_rule(),
+        rule_tests! {
+            valid => [
+                // no generic parameters
+                r#"
+                    fn foo(foo: Foo) -> Bar {}
+                "#,
+                // generic param used in multiple places
+                r#"
+                    fn foo<T: Foo>(foo: T, bar: T) -> Bar {}
+                "#,
+                // generic param used in return type
+                r#"
+                    fn foo<T: Foo>(foo: T) -> Bar<T> {}
+                "#,
+                // unconstrained generic
+                r#"
+                    fn foo<T>(foo: T) -> Bar {}
+                "#,
+                // used in onother generic constraint as well as in a param type
+                r#"
+                    fn foo<T: Foo, U: IntoIterator<Item = T>>(foo: T, bar: U) -> Bar<U> {}
+                "#,
+                // used in where clause as well as in a param type
+                r#"
+                    fn foo<T: Foo, U>(foo: T, bar: U) -> Bar<U>
+                        where U: IntoIterator<Item = T> {}
+                "#,
+            ],
+            invalid => [
+                {
+                    code => r#"
+                        fn whee<T: Foo>(t: T) -> Bar {}
+                    "#,
+                    errors => [ERROR_MESSAGE],
+                },
+                {
+                    // used in nested generic
+                    code => r#"
+                        fn whee<T: Foo>(t: Rc<T>) -> Bar {}
+                    "#,
+                    errors => [ERROR_MESSAGE],
+                },
+            ]
+        },
+    );
+}

--- a/tests/prefer_impl_param.rs
+++ b/tests/prefer_impl_param.rs
@@ -21,6 +21,10 @@ fn test_prefer_impl_param_rule() {
                 r#"
                     fn foo<T: Foo>(foo: T) -> Bar<T> {}
                 "#,
+                // generic param is return type
+                r#"
+                    fn foo<T: Foo>(foo: T) -> T {}
+                "#,
                 // unconstrained generic
                 r#"
                     fn foo<T>(foo: T) -> Bar {}


### PR DESCRIPTION
In this PR:
- a more complicated rule
- a first pass at an ESLint-ish framework for testing rules

To test:
You should be able to trigger this rule per some of the examples in the tests for the rule
If you effectively "swap" any of the "valid" test cases to be "invalid" or vice versa you should see `cargo test` fail (ie the test framework should be doing what it's supposed to)

Based on `rule-proc-macro`