### PR TITLE
Rules with state

### DIFF
--- a/src/rules/no_default_default.rs
+++ b/src/rules/no_default_default.rs
@@ -1,39 +1,83 @@
-use crate::{rule, rule::Rule, rule_listener, ViolationBuilder};
+use std::sync::Arc;
 
-pub fn no_default_default_rule() -> Rule {
-    rule! {
-        name => "no_default_default",
-        fixable => true,
-        create => |_context| {
-            vec![
-                rule_listener! {
-                    query => r#"(
-                      (call_expression
-                        function:
-                          (scoped_identifier
-                            path:
-                              (identifier) @first (#eq? @first "Default")
-                            name:
-                              (identifier) @second (#eq? @second "default")
-                          )
-                      ) @c
-                    )"#,
-                    capture_name => "c",
-                    on_query_match => |node, query_match_context| {
-                        query_match_context.report(
-                            ViolationBuilder::default()
-                                .message(r#"Use '_d()' instead of 'Default::default()'"#)
-                                .node(node)
-                                .fix(|fixer| {
-                                    fixer.replace_text(node, "_d()");
-                                })
-                                .build()
-                                .unwrap(),
-                        );
-                    }
-                }
-            ]
+use tree_sitter::Node;
+use tree_sitter_grep::SupportedLanguage;
+
+use crate::{
+    context::QueryMatchContext,
+    rule::{FileRunInfo, Rule, RuleInstance, RuleInstancePerFile, RuleListenerQuery, RuleMeta},
+    Config, ViolationBuilder,
+};
+
+pub struct NoDefaultDefaultRule {
+    listener_queries: Vec<RuleListenerQuery>,
+}
+
+impl Rule for NoDefaultDefaultRule {
+    fn meta(&self) -> RuleMeta {
+        RuleMeta {
+            name: "no_default_default".to_owned(),
+            fixable: true,
+            languages: vec![SupportedLanguage::Rust],
         }
+    }
+
+    fn listener_queries(&self) -> &[RuleListenerQuery] {
+        &self.listener_queries
+    }
+
+    fn instantiate(&self, _config: &Config) -> Arc<dyn RuleInstance> {
+        Arc::new(NoDefaultDefaultRuleInstance)
+    }
+}
+
+struct NoDefaultDefaultRuleInstance;
+
+impl RuleInstance for NoDefaultDefaultRuleInstance {
+    fn instantiate_per_file(&self, _file_run_info: &FileRunInfo) -> Arc<dyn RuleInstancePerFile> {
+        Arc::new(NoDefaultDefaultRuleInstancePerFile)
+    }
+}
+
+struct NoDefaultDefaultRuleInstancePerFile;
+
+impl RuleInstancePerFile for NoDefaultDefaultRuleInstancePerFile {
+    fn on_query_match(&self, listener_index: usize, node: Node, context: &mut QueryMatchContext) {
+        match listener_index {
+            0 => {
+                context.report(
+                    ViolationBuilder::default()
+                        .message(r#"Use '_d()' instead of 'Default::default()'"#)
+                        .node(node)
+                        .fix(|fixer| {
+                            fixer.replace_text(node, "_d()");
+                        })
+                        .build()
+                        .unwrap(),
+                );
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+pub fn no_default_default_rule() -> NoDefaultDefaultRule {
+    NoDefaultDefaultRule {
+        listener_queries: vec![RuleListenerQuery {
+            query: r#"(
+              (call_expression
+                function:
+                  (scoped_identifier
+                    path:
+                      (identifier) @first (#eq? @first "Default")
+                    name:
+                      (identifier) @second (#eq? @second "default")
+                  )
+              ) @c
+            )"#
+            .to_owned(),
+            capture_name: Some("c".to_owned()),
+        }],
     }
 }
 

--- a/src/rules/no_lazy_static.rs
+++ b/src/rules/no_lazy_static.rs
@@ -1,32 +1,73 @@
+use std::sync::Arc;
+
+use tree_sitter::Node;
+use tree_sitter_grep::SupportedLanguage;
+
 use crate::{
-    rule::{Rule, RuleBuilder, RuleListenerBuilder},
-    ViolationBuilder,
+    context::QueryMatchContext,
+    rule::{FileRunInfo, Rule, RuleInstance, RuleInstancePerFile, RuleListenerQuery, RuleMeta},
+    Config, ViolationBuilder,
 };
 
-pub fn no_lazy_static_rule() -> Rule {
-    RuleBuilder::default()
-        .name("no_lazy_static")
-        .create(|_context| {
-            vec![RuleListenerBuilder::default()
-                .query(
-                    r#"(
-                      (macro_invocation
-                         macro: (identifier) @c (#eq? @c "lazy_static")
-                      )
-                    )"#,
-                )
-                .on_query_match(|node, query_match_context| {
-                    query_match_context.report(
-                        ViolationBuilder::default()
-                            .message(r#"Prefer 'OnceCell::*::Lazy' to 'lazy_static!()'"#)
-                            .node(node)
-                            .build()
-                            .unwrap(),
-                    );
-                })
-                .build()
-                .unwrap()]
-        })
-        .build()
-        .unwrap()
+pub struct NoLazyStaticRule {
+    listener_queries: Vec<RuleListenerQuery>,
+}
+
+impl Rule for NoLazyStaticRule {
+    fn meta(&self) -> RuleMeta {
+        RuleMeta {
+            name: "no_lazy_static".to_owned(),
+            fixable: false,
+            languages: vec![SupportedLanguage::Rust],
+        }
+    }
+
+    fn listener_queries(&self) -> &[RuleListenerQuery] {
+        &self.listener_queries
+    }
+
+    fn instantiate(&self, _config: &Config) -> Arc<dyn RuleInstance> {
+        Arc::new(NoLazyStaticRuleInstance)
+    }
+}
+
+struct NoLazyStaticRuleInstance;
+
+impl RuleInstance for NoLazyStaticRuleInstance {
+    fn instantiate_per_file(&self, _file_run_info: &FileRunInfo) -> Arc<dyn RuleInstancePerFile> {
+        Arc::new(NoLazyStaticRuleInstancePerFile)
+    }
+}
+
+struct NoLazyStaticRuleInstancePerFile;
+
+impl RuleInstancePerFile for NoLazyStaticRuleInstancePerFile {
+    fn on_query_match(&self, listener_index: usize, node: Node, context: &mut QueryMatchContext) {
+        match listener_index {
+            0 => {
+                context.report(
+                    ViolationBuilder::default()
+                        .message(r#"Prefer 'OnceCell::*::Lazy' to 'lazy_static!()'"#)
+                        .node(node)
+                        .build()
+                        .unwrap(),
+                );
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+pub fn no_lazy_static_rule() -> NoLazyStaticRule {
+    NoLazyStaticRule {
+        listener_queries: vec![RuleListenerQuery {
+            query: r#"(
+              (macro_invocation
+                 macro: (identifier) @c (#eq? @c "lazy_static")
+              )
+            )"#
+            .to_owned(),
+            capture_name: None,
+        }],
+    }
 }

--- a/src/tests/fixing.rs
+++ b/src/tests/fixing.rs
@@ -1,0 +1,157 @@
+#![cfg(test)]
+
+use std::sync::Arc;
+
+use tree_sitter::Node;
+use tree_sitter_grep::SupportedLanguage;
+
+use crate::{
+    context::QueryMatchContext,
+    rule::{FileRunInfo, Rule, RuleInstance, RuleInstancePerFile, RuleListenerQuery, RuleMeta},
+    run_fixing_for_slice, Config, ConfigBuilder, ViolationBuilder,
+};
+
+#[test]
+fn test_single_fix() {
+    let mut file_contents = r#"
+        fn foo() {}
+    "#
+    .to_owned()
+    .into_bytes();
+    run_fixing_for_slice(
+        &mut file_contents,
+        "tmp.rs",
+        ConfigBuilder::default()
+            .rules([create_identifier_replacing_rule("foo", "bar")])
+            .fix(true)
+            .build()
+            .unwrap(),
+    );
+    assert_eq!(
+        std::str::from_utf8(&file_contents).unwrap().trim(),
+        r#"
+            fn bar() {}
+        "#
+        .trim()
+    );
+}
+
+struct IdentifierReplacingRule {
+    name: String,
+    replacement: String,
+    listener_queries: Vec<RuleListenerQuery>,
+}
+
+impl IdentifierReplacingRule {
+    pub fn new(name: String, replacement: String) -> Self {
+        Self {
+            name,
+            replacement,
+            listener_queries: vec![RuleListenerQuery {
+                query: r#"(
+                    (identifier) @c (#eq? @c "{}")
+                  )"#
+                .to_owned(),
+                capture_name: None,
+            }],
+        }
+    }
+}
+
+impl Rule for IdentifierReplacingRule {
+    fn meta(&self) -> RuleMeta {
+        RuleMeta {
+            name: format!("replace_{}_with_{}", self.name, self.replacement),
+            fixable: true,
+            languages: vec![SupportedLanguage::Rust],
+        }
+    }
+
+    fn listener_queries(&self) -> &[RuleListenerQuery] {
+        &self.listener_queries
+    }
+
+    fn instantiate(&self, _config: &Config) -> Arc<dyn RuleInstance> {
+        Arc::new(IdentifierReplacingRuleInstance::new(
+            self.name.clone(),
+            self.replacement.clone(),
+        ))
+    }
+}
+
+struct IdentifierReplacingRuleInstance {
+    name: String,
+    replacement: String,
+}
+
+impl IdentifierReplacingRuleInstance {
+    fn new(name: String, replacement: String) -> Self {
+        Self { name, replacement }
+    }
+}
+
+impl RuleInstance for IdentifierReplacingRuleInstance {
+    fn instantiate_per_file(&self, _file_run_info: &FileRunInfo) -> Arc<dyn RuleInstancePerFile> {
+        Arc::new(IdentifierReplacingRuleInstancePerFile::new(
+            self.name.clone(),
+            self.replacement.clone(),
+        ))
+    }
+}
+
+struct IdentifierReplacingRuleInstancePerFile {
+    name: String,
+    replacement: String,
+}
+
+impl IdentifierReplacingRuleInstancePerFile {
+    fn new(name: String, replacement: String) -> Self {
+        Self { name, replacement }
+    }
+}
+
+impl RuleInstancePerFile for IdentifierReplacingRuleInstancePerFile {
+    fn on_query_match(&self, listener_index: usize, node: Node, context: &mut QueryMatchContext) {
+        match listener_index {
+            0 => {
+                context.report(
+                    ViolationBuilder::default()
+                        .message(format!(
+                            r#"Use '{}' instead of '{}'"#,
+                            self.replacement, self.name,
+                        ))
+                        .node(node)
+                        .fix(|fixer| {
+                            fixer.replace_text(node, &self.replacement);
+                        })
+                        .build()
+                        .unwrap(),
+                );
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+fn create_identifier_replacing_rule(
+    name: impl Into<String>,
+    replacement: impl Into<String>,
+) -> Arc<dyn Rule> {
+    let name = name.into();
+    let replacement = replacement.into();
+    Arc::new(IdentifierReplacingRule::new(name, replacement))
+}
+
+// fn create_identifier_replacing_rule(
+//     name: impl Into<String>,
+//     replacement: impl Into<String>,
+// ) -> Rule { let name = name.into(); let replacement = replacement.into(); let
+//   rule_name = format!("replace_{name}_with_{replacement}"); rule! { name =>
+//   rule_name, fixable => true, state_per_run => { name: String = name,
+//   replacement: String = replacement, }, listeners => [ format!(r#"(
+//   (identifier) @c (#eq? @c "{}") )"#, name) => |node, context| {
+//   context.report( ViolationBuilder::default() .message(format!(r#"Use
+//   '{self.replacement}' instead of '{self.name}'"#)) .node(node) .fix(|fixer|
+//   { fixer.replace_text(node, &self.replacement); }) .build() .unwrap(), ); }
+//   ] }
+// }

--- a/src/tests/fixing.rs
+++ b/src/tests/fixing.rs
@@ -45,15 +45,17 @@ struct IdentifierReplacingRule {
 impl IdentifierReplacingRule {
     pub fn new(name: String, replacement: String) -> Self {
         Self {
-            name,
-            replacement,
             listener_queries: vec![RuleListenerQuery {
-                query: r#"(
-                    (identifier) @c (#eq? @c "{}")
-                  )"#
-                .to_owned(),
+                query: format!(
+                    r#"(
+                      (identifier) @c (#eq? @c "{}")
+                    )"#,
+                    name
+                ),
                 capture_name: None,
             }],
+            name,
+            replacement,
         }
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,0 +1,3 @@
+#![cfg(test)]
+
+mod fixing;


### PR DESCRIPTION
In this PR:
- driven by trying to write a testing helper for generating "simple identifier-replacement" rules, refactor the way rules are represented to in theory accommodate them having "local state" (that could be "per file-run" or "per run")

To test:
Per the added test you should be able to manually implement rules that aggregate state over the course of a "file run" and access that state from within the query listener callbacks

Based on `split-rules`