### PR TITLE
A couple fixing-related tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,7 @@ derive_builder = "0.12.0"
 proc_macros = { package = "tree_sitter_lint_proc_macros", path = "proc_macros", version = "0.0.1-dev.0" }
 regex = "1.9.1"
 tree-sitter = "0.20.10"
-# tree-sitter-grep = { package = "tree_sitter_lint_tree-sitter-grep", git = "https://github.com/helixbass/tree-sitter-grep", rev = "3c2a5678", version = "0.1.0" }
-tree-sitter-grep = { package = "tree_sitter_lint_tree-sitter-grep", path = "../tree-sitter-grep" }
+tree-sitter-grep = { package = "tree_sitter_lint_tree-sitter-grep", git = "https://github.com/helixbass/tree-sitter-grep", rev = "5fe38b38", version = "0.1.0" }
 rayon = "1.7.0"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,8 @@ derive_builder = "0.12.0"
 proc_macros = { package = "tree_sitter_lint_proc_macros", path = "proc_macros", version = "0.0.1-dev.0" }
 regex = "1.9.1"
 tree-sitter = "0.20.10"
-tree-sitter-grep = { package = "tree_sitter_lint_tree-sitter-grep", git = "https://github.com/helixbass/tree-sitter-grep", rev = "3c2a5678", version = "0.1.0" }
+# tree-sitter-grep = { package = "tree_sitter_lint_tree-sitter-grep", git = "https://github.com/helixbass/tree-sitter-grep", rev = "3c2a5678", version = "0.1.0" }
+tree-sitter-grep = { package = "tree_sitter_lint_tree-sitter-grep", path = "../tree-sitter-grep" }
 rayon = "1.7.0"
 
 [[bin]]

--- a/proc_macros/src/lib.rs
+++ b/proc_macros/src/lib.rs
@@ -638,14 +638,14 @@ fn get_rule_instance_rule_instance_impl(
             fn instantiate_per_file(
                 self: std::sync::Arc<Self>,
                 _file_run_info: &crate::rule::FileRunInfo,
-            ) -> Arc<dyn crate::rule::RuleInstancePerFile> {
-                std::sync::Arc::new(#rule_instance_per_file_struct_name {
+            ) -> Box<dyn crate::rule::RuleInstancePerFile> {
+                Box::new(#rule_instance_per_file_struct_name {
                     rule_instance: self,
                     #(#rule_instance_per_file_state_field_names: #rule_instance_per_file_state_field_initializers),*
                 })
             }
 
-            fn rule(&self) -> Arc<dyn crate::rule::Rule> {
+            fn rule(&self) -> std::sync::Arc<dyn crate::rule::Rule> {
                 self.rule.clone()
             }
 
@@ -765,7 +765,7 @@ fn get_rule_instance_per_file_rule_instance_per_file_impl(
     });
     quote! {
         impl crate::rule::RuleInstancePerFile for #rule_instance_per_file_struct_name {
-            fn on_query_match(&self, listener_index: usize, node: tree_sitter::Node, context: &mut crate::context::QueryMatchContext) {
+            fn on_query_match(&mut self, listener_index: usize, node: tree_sitter::Node, context: &mut crate::context::QueryMatchContext) {
                 match listener_index {
                     #(#listener_indices => {
                         #listener_callbacks

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -21,7 +21,7 @@ pub trait RuleInstance: Send + Sync {
     fn instantiate_per_file(
         self: Arc<Self>,
         file_run_info: &FileRunInfo,
-    ) -> Arc<dyn RuleInstancePerFile>;
+    ) -> Box<dyn RuleInstancePerFile>;
     fn rule(&self) -> Arc<dyn Rule>;
     fn listener_queries(&self) -> &[RuleListenerQuery];
 }
@@ -43,7 +43,12 @@ impl InstantiatedRule {
 }
 
 pub trait RuleInstancePerFile: Send + Sync {
-    fn on_query_match(&self, listener_index: usize, node: Node, context: &mut QueryMatchContext);
+    fn on_query_match(
+        &mut self,
+        listener_index: usize,
+        node: Node,
+        context: &mut QueryMatchContext,
+    );
     fn rule_instance(&self) -> Arc<dyn RuleInstance>;
 }
 

--- a/src/rule_tester.rs
+++ b/src/rule_tester.rs
@@ -40,6 +40,7 @@ impl RuleTester {
             "tmp.rs",
             ConfigBuilder::default()
                 .rule(&self.rule.meta().name)
+                .rules([self.rule.clone()])
                 .build()
                 .unwrap(),
         );
@@ -53,6 +54,7 @@ impl RuleTester {
             "tmp.rs",
             ConfigBuilder::default()
                 .rule(&self.rule.meta().name)
+                .rules([self.rule.clone()])
                 .fix(true)
                 .report_fixed_violations(true)
                 .build()

--- a/src/tests/fixing.rs
+++ b/src/tests/fixing.rs
@@ -39,6 +39,84 @@ fn test_single_fix() {
     );
 }
 
+#[test]
+fn test_cascading_fixes() {
+    assert_fixed_content!(
+        r#"
+            fn foo() {}
+        "#,
+        [
+            create_identifier_replacing_rule("foo", "bar"),
+            create_identifier_replacing_rule("bar", "baz"),
+        ],
+        r#"
+            fn baz() {}
+        "#
+    );
+}
+
+#[test]
+fn test_more_than_limit_fix_iterations() {
+    assert_fixed_content!(
+        r#"
+            fn foo() {}
+        "#,
+        [
+            create_identifier_replacing_rule("foo", "foo1"),
+            create_identifier_replacing_rule("foo1", "foo2"),
+            create_identifier_replacing_rule("foo2", "foo3"),
+            create_identifier_replacing_rule("foo3", "foo4"),
+            create_identifier_replacing_rule("foo4", "foo5"),
+            create_identifier_replacing_rule("foo5", "foo6"),
+            create_identifier_replacing_rule("foo6", "foo7"),
+            create_identifier_replacing_rule("foo7", "foo8"),
+            create_identifier_replacing_rule("foo8", "foo9"),
+            create_identifier_replacing_rule("foo9", "foo10"),
+            create_identifier_replacing_rule("foo10", "foo11"),
+            create_identifier_replacing_rule("foo11", "foo12"),
+        ],
+        r#"
+            fn foo10() {}
+        "#
+    );
+}
+
+#[test]
+fn test_conflicting_fixes() {
+    assert_fixed_content!(
+        r#"
+            fn start() {}
+        "#,
+        [
+            create_identifier_replacing_rule("start", "option1"),
+            create_identifier_replacing_rule("start", "option2"),
+            create_identifier_replacing_rule("option1", "end"),
+            create_identifier_replacing_rule("option2", "end"),
+        ],
+        r#"
+            fn end() {}
+        "#
+    );
+}
+
+#[test]
+fn test_multiple_nonconflicting_fixes_from_different_rules() {
+    assert_fixed_content!(
+        r#"
+            fn foo() {}
+            fn bar() {}
+        "#,
+        [
+            create_identifier_replacing_rule("foo", "baz"),
+            create_identifier_replacing_rule("bar", "byz")
+        ],
+        r#"
+            fn baz() {}
+            fn byz() {}
+        "#
+    );
+}
+
 fn create_identifier_replacing_rule(
     name: impl Into<String>,
     replacement: impl Into<String>,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,3 +1,4 @@
 #![cfg(test)]
 
 mod fixing;
+mod rules;

--- a/src/tests/rules.rs
+++ b/src/tests/rules.rs
@@ -1,0 +1,63 @@
+#![cfg(test)]
+
+use std::sync::Arc;
+
+use proc_macros::{rule, rule_tests};
+
+use crate::{rule::Rule, violation, RuleTester};
+
+#[test]
+fn test_per_file_run_state() {
+    RuleTester::run(
+        no_more_than_5_uses_of_foo_rule(),
+        rule_tests! {
+            valid => [
+                r#"
+                    fn foo() {
+                        let foo = foo;
+                        foo();
+                        foo();
+                    }
+                "#,
+            ],
+            invalid => [
+                {
+                    code => r#"
+                        fn foo() {
+                            let foo = foo;
+                            foo();
+                            foo();
+                            foo();
+                        }
+                    "#,
+                    errors => [r#"Can't use 'foo' more than 5 times"#],
+                },
+            ]
+        },
+    );
+}
+
+fn no_more_than_5_uses_of_foo_rule() -> Arc<dyn Rule> {
+    rule! {
+        name => "no_more_than_5_uses_of_foo",
+        state => {
+            [per-file-run]
+            num_foos: usize
+        },
+        listeners => [
+            r#"(
+              (identifier) @c (#eq? @c "foo")
+            )"# => |node, context| {
+                self.num_foos += 1;
+                if self.num_foos > 5 {
+                    context.report(
+                        violation! {
+                            node => node,
+                            message => r#"Can't use 'foo' more than 5 times"#,
+                        }
+                    );
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
In this PR:
- add a couple tests for fixing and rule state
- enable mutable access to eg per-file-run rule state (eg in rule listener callbacks) by using a different newly-exposed `tree_sitter_grep` endpoint that does an extra layer of "callback indirection" to establish the fact that within the context of a given file things are happening "serially"

To test:
Per the one rules test you should be able to write rules that mutate "per-file-run" fields on `self` 

Based on `rule-macro`