### PR TITLE
Config file

### DIFF
--- a/.tree-sitter-lint.yml
+++ b/.tree-sitter-lint.yml
@@ -1,4 +1,7 @@
 rules:
-  no_default_default: error
-  prefer_impl_param: error
-  no_lazy_static: error
+  no_default_default:
+    level: error
+  prefer_impl_param:
+    level: error
+  no_lazy_static:
+    level: error

--- a/.tree-sitter-lint.yml
+++ b/.tree-sitter-lint.yml
@@ -1,0 +1,4 @@
+rules:
+  no_default_default: error
+  prefer_impl_param: error
+  no_lazy_static: error

--- a/.tree-sitter-lint/tree-sitter-lint-local/src/main.rs
+++ b/.tree-sitter-lint/tree-sitter-lint-local/src/main.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use tree_sitter_lint::{clap::Parser, Args, Rule};
 
 fn main() {
-    tree_sitter_lint::run_and_output(Args::parse().into_config(all_rules()));
+    tree_sitter_lint::run_and_output(Args::parse().load_config_file_and_into_config(all_rules()));
 }
 
 fn all_rules() -> Vec<Arc<dyn Rule>> {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ regex = "1.9.1"
 tree-sitter = "0.20.10"
 tree-sitter-grep = { package = "tree_sitter_lint_tree-sitter-grep", git = "https://github.com/helixbass/tree-sitter-grep", rev = "5fe38b38", version = "0.1.0" }
 rayon = "1.7.0"
+serde = "1.0.175"
+serde_yaml = "0.9.25"
 
 [[bin]]
 name = "tree-sitter-lint"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use clap::Parser;
 use derive_builder::Builder;
@@ -18,18 +18,21 @@ pub struct Args {
 }
 
 impl Args {
-    pub fn into_config(self, rules: Vec<Arc<dyn Rule>>) -> Config {
+    pub fn load_config_file_and_into_config(self, all_rules: Vec<Arc<dyn Rule>>) -> Config {
+        let config_file = load_config_file();
         let Args {
             rule,
             fix,
             report_fixed_violations,
         } = self;
-        Config {
+        let config = Config {
             rule,
-            rules,
+            all_rules,
             fix,
             report_fixed_violations,
-        }
+            config_file,
+        };
+        config
     }
 }
 
@@ -39,29 +42,75 @@ pub struct Config {
     #[builder(default)]
     pub rule: Option<String>,
 
-    rules: Vec<Arc<dyn Rule>>,
+    all_rules: Vec<Arc<dyn Rule>>,
 
     #[builder(default)]
     pub fix: bool,
 
     #[builder(default)]
     pub report_fixed_violations: bool,
+
+    pub config_file: ParsedConfigFile,
 }
 
 impl Config {
-    fn rules(&self) -> &[Arc<dyn Rule>] {
-        &self.rules
+    fn get_active_rules(&self) -> Vec<Arc<dyn Rule>> {
+        self.config_file
+            .content
+            .rules
+            .iter()
+            .filter(|rule_config| rule_config.level != ErrorLevel::Off)
+            .map(|rule_config| {
+                self.all_rules
+                    .iter()
+                    .find(|rule| rule.meta().name == rule_config.name)
+                    .unwrap_or_else(|| panic!("Unknown rule: '{}'", rule_config.name))
+                    .clone()
+            })
+            .collect()
+    }
+
+    fn filter_based_on_rule_argument(
+        &self,
+        active_rules: Vec<Arc<dyn Rule>>,
+    ) -> Vec<Arc<dyn Rule>> {
+        match self.rule.as_ref() {
+            Some(rule_arg) => {
+                let filtered = active_rules
+                    .into_iter()
+                    .filter(|rule| &rule.meta().name == rule_arg)
+                    .collect::<Vec<_>>();
+                if !filtered.is_empty() {
+                    return filtered;
+                }
+                self.rule_argument_error();
+            }
+            None => active_rules,
+        }
+    }
+
+    fn rule_argument_error(&self) -> ! {
+        let rule_arg = self.rule.as_ref().unwrap();
+        if self
+            .all_rules
+            .iter()
+            .any(|rule| &rule.meta().name == rule_arg)
+        {
+            panic!("The '{rule_arg}' rule is configured as inactive");
+        } else {
+            panic!("Unknown rule: '{rule_arg}'");
+        }
     }
 
     pub fn get_instantiated_rules(&self) -> Vec<InstantiatedRule> {
-        let instantiated_rules = self
-            .rules()
+        let active_rules = self.get_active_rules();
+        if active_rules.is_empty() {
+            panic!("No configured active rules");
+        }
+        let active_rules = self.filter_based_on_rule_argument(active_rules);
+        let instantiated_rules = active_rules
             .into_iter()
             .map(|rule| InstantiatedRule::new(rule.clone(), self))
-            .filter(|rule| match self.rule.as_ref() {
-                Some(rule_arg) => &rule.meta.name == rule_arg,
-                None => true,
-            })
             .collect::<Vec<_>>();
         if instantiated_rules.is_empty() {
             panic!("Invalid rule name: {:?}", self.rule.as_ref().unwrap());
@@ -69,3 +118,28 @@ impl Config {
         instantiated_rules
     }
 }
+
+#[derive(Clone)]
+struct ParsedConfigFile {
+    pub path: PathBuf,
+    pub content: ParsedConfigFileContent,
+}
+
+#[derive(Clone)]
+struct ParsedConfigFileContent {
+    pub rules: Vec<RuleConfiguration>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum ErrorLevel {
+    Error,
+    Off,
+}
+
+#[derive(Clone)]
+struct RuleConfiguration {
+    pub name: String,
+    pub level: ErrorLevel,
+}
+
+fn load_config_file() -> ParsedConfigFile {}

--- a/src/rule_tester.rs
+++ b/src/rule_tester.rs
@@ -41,6 +41,7 @@ impl RuleTester {
             ConfigBuilder::default()
                 .rule(&self.rule.meta().name)
                 .all_rules([self.rule.clone()])
+                .default_rule_configurations()
                 .build()
                 .unwrap(),
         );
@@ -55,6 +56,7 @@ impl RuleTester {
             ConfigBuilder::default()
                 .rule(&self.rule.meta().name)
                 .all_rules([self.rule.clone()])
+                .default_rule_configurations()
                 .fix(true)
                 .report_fixed_violations(true)
                 .build()

--- a/src/rule_tester.rs
+++ b/src/rule_tester.rs
@@ -40,7 +40,7 @@ impl RuleTester {
             "tmp.rs",
             ConfigBuilder::default()
                 .rule(&self.rule.meta().name)
-                .rules([self.rule.clone()])
+                .all_rules([self.rule.clone()])
                 .build()
                 .unwrap(),
         );
@@ -54,7 +54,7 @@ impl RuleTester {
             "tmp.rs",
             ConfigBuilder::default()
                 .rule(&self.rule.meta().name)
-                .rules([self.rule.clone()])
+                .all_rules([self.rule.clone()])
                 .fix(true)
                 .report_fixed_violations(true)
                 .build()

--- a/src/tests/fixing.rs
+++ b/src/tests/fixing.rs
@@ -15,6 +15,7 @@ macro_rules! assert_fixed_content {
             "tmp.rs",
             $crate::ConfigBuilder::default()
                 .all_rules($rules)
+                .default_rule_configurations()
                 .fix(true)
                 .build()
                 .unwrap(),

--- a/src/tests/fixing.rs
+++ b/src/tests/fixing.rs
@@ -14,7 +14,7 @@ macro_rules! assert_fixed_content {
             &mut file_contents,
             "tmp.rs",
             $crate::ConfigBuilder::default()
-                .rules($rules)
+                .all_rules($rules)
                 .fix(true)
                 .build()
                 .unwrap(),


### PR DESCRIPTION
In this PR:
- basic support for requiring a `.tree-sitter-lint.yml` config file which can configure rules as on/off

To test:
As this is based on the preceding PR you will need to manually `$ cd .tree-sitter-lint/tree-sitter-lint-local && cargo build --release` to manually "freshen" your "local custom binary"
At that point you should be able to run eg `cargo run` (from the repo root) and see it working
And if you change a rule's configuration to `level: off` in `.tree-sitter-lint.yml` it should no longer run/show violations for that rule
If you change all the rule configurations to `level: off` it should yell at you for not having any active rules
If you run against another eg Rust project directory (via eg `cargo run --manifest-path ../path/to/tree-sitter-lint/Cargo.toml`) it should yell at you for not being able to find a `.tree-sitter-lint.yml` config file
If you then add a `.tree-sitter-lint.yml` config file in that directory (similar to the one committed here) it should work

Based on `local-rules`