### PR TITLE
Re-generate local custom binary

### DIFF
--- a/.tree-sitter-lint.yml
+++ b/.tree-sitter-lint.yml
@@ -1,6 +1,6 @@
 plugins:
-  replace-foo-with-bar:
-    path: ./examples/tree-sitter-lint-plugin-replace-foo-with-bar
+  replace-foo-with:
+    path: ./tests/fixtures/tree-sitter-lint-plugin-replace-foo-with
 rules:
   no-default-default:
     level: error

--- a/.tree-sitter-lint/tree-sitter-lint-local/Cargo.toml
+++ b/.tree-sitter-lint/tree-sitter-lint-local/Cargo.toml
@@ -3,9 +3,7 @@ name = "tree-sitter-lint-local"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-local_rules = { path = "../local_rules" }
 tree-sitter-lint = { path = "../.." }
-tree-sitter-lint-plugin-replace-foo-with = { path = "../../tests/fixtures/tree-sitter-lint-plugin-replace-foo-with" }
+local_rules = { path = "../local_rules" }
+tree-sitter-lint-plugin-replace-foo-with = { path = "../.././tests/fixtures/tree-sitter-lint-plugin-replace-foo-with" }

--- a/.tree-sitter-lint/tree-sitter-lint-local/src/main.rs
+++ b/.tree-sitter-lint/tree-sitter-lint-local/src/main.rs
@@ -1,17 +1,1 @@
-use std::sync::Arc;
-
-use tree_sitter_lint::{clap::Parser, Args, Plugin, Rule};
-
-fn main() {
-    tree_sitter_lint::run_and_output(
-        Args::parse().load_config_file_and_into_config(all_plugins(), all_standalone_rules()),
-    );
-}
-
-fn all_plugins() -> Vec<Plugin> {
-    vec![tree_sitter_lint_plugin_replace_foo_with::instantiate()]
-}
-
-fn all_standalone_rules() -> Vec<Arc<dyn Rule>> {
-    local_rules::get_rules()
-}
+use std :: sync :: Arc ; use tree_sitter_lint :: { clap :: Parser , Args , Plugin , Rule } ; fn main () { tree_sitter_lint :: run_and_output (Args :: parse () . load_config_file_and_into_config (all_plugins () , all_standalone_rules ()) ,) ; } fn all_plugins () -> Vec < Plugin > { vec ! [tree_sitter_lint_plugin_replace_foo_with :: instantiate ()] } fn all_standalone_rules () -> Vec < Arc < dyn Rule >> { local_rules :: get_rules () }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ rayon = "1.7.0"
 serde = "1.0.175"
 serde_yaml = "0.9.25"
 serde_json = "1.0.103"
+quote = "1.0.32"
+Inflector = "0.11.4"
 
 [[bin]]
 name = "tree-sitter-lint"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -56,10 +56,14 @@ fn regenerate_local_binary(
     local_binary_project_directory: &Path,
     relative_path_from_local_binary_project_directory_to_project_directory: &Path,
 ) {
+    eprintln!("Config changed, regenerating local binary");
     let parsed_config_file = load_config_file();
+    let local_binary_project_src_directory = local_binary_project_directory.join("src");
+    let local_binary_project_cargo_toml_path = local_binary_project_directory.join("Cargo.toml");
     if local_binary_project_directory.is_dir() {
-        fs::remove_dir_all(local_binary_project_directory)
-            .expect("Couldn't remove existing local binary project");
+        let _ = fs::remove_dir_all(&local_binary_project_src_directory);
+        let _ = fs::remove_file(&local_binary_project_cargo_toml_path);
+        let _ = fs::remove_file(local_binary_project_directory.join("Cargo.lock"));
     }
     fs::create_dir_all(local_binary_project_directory)
         .expect("Couldn't create local binary project directory");
@@ -74,13 +78,9 @@ fn regenerate_local_binary(
         has_local_rules,
         relative_path_from_local_binary_project_directory_to_project_directory,
     );
-    fs::write(
-        local_binary_project_directory.join("Cargo.toml"),
-        cargo_toml_contents,
-    )
-    .expect("Couldn't write local binary project Cargo.toml");
+    fs::write(local_binary_project_cargo_toml_path, cargo_toml_contents)
+        .expect("Couldn't write local binary project Cargo.toml");
 
-    let local_binary_project_src_directory = local_binary_project_directory.join("src");
     fs::create_dir(&local_binary_project_src_directory)
         .expect("Couldn't create local binary project `src/` directory");
     let src_main_rs_contents = get_src_main_rs_contents(&parsed_config_file, has_local_rules);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,14 +1,195 @@
 use std::{
-    env,
+    env, fs,
+    path::Path,
     process::{self, Command},
 };
 
+use inflector::Inflector;
+use quote::{format_ident, quote};
+
+use crate::config::{find_config_file, load_config_file, ParsedConfigFile};
+
+const PER_PROJECT_DIRECTORY_NAME: &str = ".tree-sitter-lint";
+
+const LOCAL_BINARY_PROJECT_NAME: &str = "tree-sitter-lint-local";
+
 pub fn bootstrap_cli() {
-    let path_to_local_binary =
-        "/Users/jrosse/prj/tree-sitter-lint/.tree-sitter-lint/tree-sitter-lint-local/target/release/tree-sitter-lint-local";
-    let mut handle = Command::new(path_to_local_binary)
+    let config_file_path = find_config_file();
+    let project_directory = config_file_path.parent().unwrap();
+    let per_project_directory = project_directory.join(PER_PROJECT_DIRECTORY_NAME);
+    let local_binary_project_directory = per_project_directory.join(LOCAL_BINARY_PROJECT_NAME);
+    let path_to_local_release_binary =
+        local_binary_project_directory.join(format!("target/release/{LOCAL_BINARY_PROJECT_NAME}"));
+    if should_regenerate_local_binary(&config_file_path, &path_to_local_release_binary) {
+        regenerate_local_binary(&local_binary_project_directory, &Path::new("..").join(".."));
+    }
+    let mut handle = Command::new(path_to_local_release_binary)
         .args(env::args_os().skip(1))
         .spawn()
         .unwrap();
     process::exit(handle.wait().unwrap().code().unwrap_or(1));
+}
+
+fn should_regenerate_local_binary(
+    config_file_path: &Path,
+    path_to_local_release_binary: &Path,
+) -> bool {
+    let local_release_binary_modified_timestamp = match path_to_local_release_binary
+        .metadata()
+        .ok()
+        .and_then(|metadata| metadata.modified().ok())
+    {
+        None => return true,
+        Some(timestamp) => timestamp,
+    };
+    let config_file_modified_timestamp = config_file_path
+        .metadata()
+        .expect("Couldn't read config file metadata")
+        .modified()
+        .expect("Couldn't get config file modified timestamp");
+    config_file_modified_timestamp > local_release_binary_modified_timestamp
+}
+
+const LOCAL_RULES_DIR_NAME: &str = "local_rules";
+
+fn regenerate_local_binary(
+    local_binary_project_directory: &Path,
+    relative_path_from_local_binary_project_directory_to_project_directory: &Path,
+) {
+    let parsed_config_file = load_config_file();
+    if local_binary_project_directory.is_dir() {
+        fs::remove_dir_all(local_binary_project_directory)
+            .expect("Couldn't remove existing local binary project");
+    }
+    fs::create_dir_all(local_binary_project_directory)
+        .expect("Couldn't create local binary project directory");
+    let has_local_rules = local_binary_project_directory
+        .parent()
+        .unwrap()
+        .join(LOCAL_RULES_DIR_NAME)
+        .is_dir();
+
+    let cargo_toml_contents = get_local_binary_cargo_toml_contents(
+        &parsed_config_file,
+        has_local_rules,
+        relative_path_from_local_binary_project_directory_to_project_directory,
+    );
+    fs::write(
+        local_binary_project_directory.join("Cargo.toml"),
+        cargo_toml_contents,
+    )
+    .expect("Couldn't write local binary project Cargo.toml");
+
+    let local_binary_project_src_directory = local_binary_project_directory.join("src");
+    fs::create_dir(&local_binary_project_src_directory)
+        .expect("Couldn't create local binary project `src/` directory");
+    let src_main_rs_contents = get_src_main_rs_contents(&parsed_config_file, has_local_rules);
+    fs::write(
+        local_binary_project_src_directory.join("main.rs"),
+        src_main_rs_contents,
+    )
+    .expect("Couldn't write local binary project src/main.rs");
+
+    let gitignore_contents = get_gitignore_contents();
+    fs::write(
+        local_binary_project_directory.join(".gitignore"),
+        gitignore_contents,
+    )
+    .expect("Couldn't write local binary project .gitignore");
+
+    release_build_local_binary(local_binary_project_directory);
+}
+
+fn release_build_local_binary(local_binary_project_directory: &Path) {
+    let output = Command::new("cargo")
+        .args(["build", "--release"])
+        .current_dir(local_binary_project_directory)
+        .output()
+        .expect("Failed to execute cargo release build command");
+    if !output.status.success() {
+        panic!("Cargo release build of local binary project failed");
+    }
+}
+
+fn get_local_binary_cargo_toml_contents(
+    parsed_config_file: &ParsedConfigFile,
+    has_local_rules: bool,
+    relative_path_from_local_binary_project_directory_to_project_directory: &Path,
+) -> String {
+    let mut contents = String::new();
+    contents.push_str("[package]\n");
+    contents.push_str(&format!("name = \"{}\"\n", LOCAL_BINARY_PROJECT_NAME));
+    contents.push_str("version = \"0.1.0\"\n");
+    contents.push_str("edition = \"2021\"\n\n");
+    contents.push_str("[dependencies]\n");
+    contents.push_str("tree-sitter-lint = { path = \"../..\" }\n");
+    if has_local_rules {
+        contents.push_str(&format!(
+            "local_rules = {{ path = \"../{}\" }}\n",
+            LOCAL_RULES_DIR_NAME
+        ));
+    }
+    for (plugin, plugin_spec) in &parsed_config_file.content.plugins {
+        let path = plugin_spec
+            .path
+            .as_ref()
+            .expect("Currently only handling local path plugin dependencies");
+        let path =
+            relative_path_from_local_binary_project_directory_to_project_directory.join(path);
+        contents.push_str(&format!(
+            "{} = {{ path = \"{}\" }}\n",
+            get_plugin_crate_name(plugin),
+            path.to_str()
+                .expect("Couldn't convert plugin path to string")
+        ));
+    }
+    contents
+}
+
+fn get_src_main_rs_contents(
+    parsed_config_file: &ParsedConfigFile,
+    has_local_rules: bool,
+) -> String {
+    let standalone_rules = if has_local_rules {
+        quote!(local_rules::get_rules())
+    } else {
+        quote!(vec![])
+    };
+
+    let plugin_crates = parsed_config_file
+        .content
+        .plugins
+        .keys()
+        .map(|plugin_name| format_ident!("{}", get_plugin_crate_name(plugin_name).to_snake_case()));
+
+    quote! {
+        use std::sync::Arc;
+
+        use tree_sitter_lint::{clap::Parser, Args, Plugin, Rule};
+
+        fn main() {
+            tree_sitter_lint::run_and_output(
+                Args::parse().load_config_file_and_into_config(all_plugins(), all_standalone_rules()),
+            );
+        }
+
+        fn all_plugins() -> Vec<Plugin> {
+            vec![#(#plugin_crates::instantiate()),*]
+        }
+
+        fn all_standalone_rules() -> Vec<Arc<dyn Rule>> {
+            #standalone_rules
+        }
+    }.to_string()
+}
+
+fn get_gitignore_contents() -> String {
+    let mut contents = String::new();
+    contents.push_str("/target\n");
+    contents.push_str("/Cargo.lock\n");
+    contents
+}
+
+fn get_plugin_crate_name(plugin_name: &str) -> String {
+    format!("tree-sitter-lint-plugin-{plugin_name}")
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -266,7 +266,7 @@ impl RuleConfiguration {
     }
 }
 
-fn load_config_file() -> ParsedConfigFile {
+pub fn load_config_file() -> ParsedConfigFile {
     let config_file_path = find_config_file();
     let config_file_contents =
         fs::read_to_string(&config_file_path).expect("Couldn't read config file contents");
@@ -280,7 +280,7 @@ fn load_config_file() -> ParsedConfigFile {
 
 const CONFIG_FILENAME: &str = ".tree-sitter-lint.yml";
 
-fn find_config_file() -> PathBuf {
+pub fn find_config_file() -> PathBuf {
     find_filename_in_ancestor_directory(
         CONFIG_FILENAME,
         env::current_dir().expect("Couldn't get current directory"),


### PR DESCRIPTION
In this PR:
- first pass at re-generating the custom local binary Cargo project (and release-build-ing it) if it is stale/nonexistent wrt the project config file (`.tree-sitter-lint.yml`)

To test:
If you remove the local `.tree-sitter-lint/tree-sitter-lint-local/` directory and `cargo run` it should tell you that it's re-generating the local binary and then take a while and then show you any linting errors
If you then `cargo run` it should not do any re-generating and should show you any linting errors
If you then `$ touch .tree-sitter-lint.yml` and `cargo run` it should tell you that it's re-generating and do that significantly more quickly and then show you any linting errors
It doesn't quite work to run this against another project directory (with its own `.tree-sitter-lint.yml`) because the path from the custom local binary to the `tree-sitter-lint` path-local dependency is hard-coded in its `Cargo.toml` as `tree-sitter-lint = { path = "../.." }` (which isn't the right relative path for other project directories)

Based on `rule-options`