### PR TITLE
Generate custom LSP binary locally

### DIFF
--- a/.tree-sitter-lint/tree-sitter-lint-local/Cargo.toml
+++ b/.tree-sitter-lint/tree-sitter-lint-local/Cargo.toml
@@ -13,3 +13,4 @@ name = "tree-sitter-lint-local"
 
 [[bin]]
 name = "tree-sitter-lint-local-lsp"
+

--- a/.tree-sitter-lint/tree-sitter-lint-local/Cargo.toml
+++ b/.tree-sitter-lint/tree-sitter-lint-local/Cargo.toml
@@ -10,3 +10,6 @@ tree-sitter-lint-plugin-replace-foo-with = { path = "../.././tests/fixtures/tree
 
 [[bin]]
 name = "tree-sitter-lint-local"
+
+[[bin]]
+name = "tree-sitter-lint-local-lsp"

--- a/.tree-sitter-lint/tree-sitter-lint-local/src/bin/tree-sitter-lint-local-lsp.rs
+++ b/.tree-sitter-lint/tree-sitter-lint-local/src/bin/tree-sitter-lint-local-lsp.rs
@@ -1,5 +1,4 @@
 use tree_sitter_lint::tokio;
-
 #[tokio::main]
 async fn main() {
     tree_sitter_lint_local::run_lsp().await;

--- a/.tree-sitter-lint/tree-sitter-lint-local/src/bin/tree-sitter-lint-local-lsp.rs
+++ b/.tree-sitter-lint/tree-sitter-lint-local/src/bin/tree-sitter-lint-local-lsp.rs
@@ -1,0 +1,6 @@
+use tree_sitter_lint::tokio;
+
+#[tokio::main]
+async fn main() {
+    tree_sitter_lint_local::run_lsp().await;
+}

--- a/.tree-sitter-lint/tree-sitter-lint-local/src/lib.rs
+++ b/.tree-sitter-lint/tree-sitter-lint-local/src/lib.rs
@@ -2,7 +2,7 @@ use std::{path::Path, sync::Arc};
 
 use tree_sitter_lint::{
     clap::Parser, tree_sitter::Tree, tree_sitter_grep::RopeOrSlice, Args, Config, MutRopeOrSlice,
-    Plugin, Rule, ViolationWithContext,
+    Plugin, Rule, ViolationWithContext, lsp::{LocalLinter, self},
 };
 
 pub fn run_and_output() {
@@ -25,6 +25,34 @@ pub fn run_fixing_for_slice<'a>(
     args: Args,
 ) -> Vec<ViolationWithContext> {
     tree_sitter_lint::run_fixing_for_slice(file_contents, tree, path, args_to_config(args))
+}
+
+struct LocalLinterConcrete;
+
+impl LocalLinter for LocalLinterConcrete {
+    fn run_for_slice<'a>(
+        &self,
+        file_contents: impl Into<RopeOrSlice<'a>>,
+        tree: Option<&Tree>,
+        path: impl AsRef<Path>,
+        args: Args,
+    ) -> Vec<ViolationWithContext> {
+        run_for_slice(file_contents, tree, path, args)
+    }
+
+    fn run_fixing_for_slice<'a>(
+        &self,
+        file_contents: impl Into<MutRopeOrSlice<'a>>,
+        tree: Option<&Tree>,
+        path: impl AsRef<Path>,
+        args: Args,
+    ) -> Vec<ViolationWithContext> {
+        run_fixing_for_slice(file_contents, tree, path, args)
+    }
+}
+
+pub async fn run_lsp() {
+    lsp::run(LocalLinterConcrete).await;
 }
 
 fn args_to_config(args: Args) -> Config {

--- a/.tree-sitter-lint/tree-sitter-lint-local/src/lib.rs
+++ b/.tree-sitter-lint/tree-sitter-lint-local/src/lib.rs
@@ -1,14 +1,15 @@
 use std::{path::Path, sync::Arc};
 
 use tree_sitter_lint::{
-    clap::Parser, tree_sitter::Tree, tree_sitter_grep::RopeOrSlice, Args, Config, MutRopeOrSlice,
-    Plugin, Rule, ViolationWithContext, lsp::{LocalLinter, self},
+    clap::Parser,
+    lsp::{self, LocalLinter},
+    tree_sitter::Tree,
+    tree_sitter_grep::RopeOrSlice,
+    Args, Config, MutRopeOrSlice, Plugin, Rule, ViolationWithContext,
 };
-
 pub fn run_and_output() {
     tree_sitter_lint::run_and_output(args_to_config(Args::parse()));
 }
-
 pub fn run_for_slice<'a>(
     file_contents: impl Into<RopeOrSlice<'a>>,
     tree: Option<&Tree>,
@@ -17,7 +18,6 @@ pub fn run_for_slice<'a>(
 ) -> Vec<ViolationWithContext> {
     tree_sitter_lint::run_for_slice(file_contents, tree, path, args_to_config(args))
 }
-
 pub fn run_fixing_for_slice<'a>(
     file_contents: impl Into<MutRopeOrSlice<'a>>,
     tree: Option<&Tree>,
@@ -26,9 +26,7 @@ pub fn run_fixing_for_slice<'a>(
 ) -> Vec<ViolationWithContext> {
     tree_sitter_lint::run_fixing_for_slice(file_contents, tree, path, args_to_config(args))
 }
-
 struct LocalLinterConcrete;
-
 impl LocalLinter for LocalLinterConcrete {
     fn run_for_slice<'a>(
         &self,
@@ -39,7 +37,6 @@ impl LocalLinter for LocalLinterConcrete {
     ) -> Vec<ViolationWithContext> {
         run_for_slice(file_contents, tree, path, args)
     }
-
     fn run_fixing_for_slice<'a>(
         &self,
         file_contents: impl Into<MutRopeOrSlice<'a>>,
@@ -50,19 +47,15 @@ impl LocalLinter for LocalLinterConcrete {
         run_fixing_for_slice(file_contents, tree, path, args)
     }
 }
-
 pub async fn run_lsp() {
     lsp::run(LocalLinterConcrete).await;
 }
-
 fn args_to_config(args: Args) -> Config {
     args.load_config_file_and_into_config(all_plugins(), all_standalone_rules())
 }
-
 fn all_plugins() -> Vec<Plugin> {
     vec![tree_sitter_lint_plugin_replace_foo_with::instantiate()]
 }
-
 fn all_standalone_rules() -> Vec<Arc<dyn Rule>> {
     local_rules::get_rules()
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ serde_yaml = "0.9.25"
 serde_json = "1.0.103"
 quote = "1.0.32"
 Inflector = "0.11.4"
+dashmap = "5.5.0"
+text-diff = "0.4.0"
+tower-lsp = "0.19.0"
+tokio = { version = "1.29.1", features = ["full"] }
 
 [[bin]]
 name = "tree-sitter-lint"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -4,3 +4,4 @@ format_macro_matchers = true
 group_imports = "StdExternalCrate"
 imports_granularity = "Crate"
 wrap_comments = true
+edition = "2021"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 mod cli;
 mod config;
 mod context;
+pub mod lsp;
 mod macros;
 mod plugin;
 mod rule;
@@ -41,6 +42,7 @@ pub use violation::{ViolationBuilder, ViolationWithContext};
 
 pub extern crate clap;
 pub extern crate serde_json;
+pub extern crate tokio;
 pub extern crate tree_sitter_grep;
 pub use tree_sitter_grep::{ropey, tree_sitter};
 

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -1,0 +1,360 @@
+use std::{borrow::Cow, ops, path::Path};
+
+use dashmap::DashMap;
+use text_diff::Difference;
+use tower_lsp::{
+    jsonrpc::Result,
+    lsp_types::{
+        Diagnostic, DiagnosticSeverity, DidChangeTextDocumentParams, DidOpenTextDocumentParams,
+        DocumentChanges, ExecuteCommandOptions, ExecuteCommandParams, InitializeParams,
+        InitializeResult, InitializedParams, NumberOrString, OneOf,
+        OptionalVersionedTextDocumentIdentifier, Position, Range, ServerCapabilities,
+        TextDocumentEdit, TextDocumentSyncCapability, TextDocumentSyncKind, TextEdit, Url,
+        WorkspaceEdit,
+    },
+    Client, LanguageServer, LspService, Server,
+};
+use tree_sitter_grep::{ropey::Rope, RopeOrSlice};
+use crate::{
+    tree_sitter::{self, InputEdit, Parser, Point, Tree},
+    tree_sitter_grep::{Parseable, SupportedLanguage},
+    ArgsBuilder, ViolationWithContext, Args, MutRopeOrSlice,
+};
+
+const APPLY_ALL_FIXES_COMMAND: &str = "tree-sitter-lint.applyAllFixes";
+
+pub trait LocalLinter: Send + Sync {
+    fn run_for_slice<'a>(
+        &self,
+        file_contents: impl Into<RopeOrSlice<'a>>,
+        tree: Option<&Tree>,
+        path: impl AsRef<Path>,
+        args: Args,
+    ) -> Vec<ViolationWithContext>;
+
+    fn run_fixing_for_slice<'a>(
+        &self,
+        file_contents: impl Into<MutRopeOrSlice<'a>>,
+        tree: Option<&Tree>,
+        path: impl AsRef<Path>,
+        args: Args,
+    ) -> Vec<ViolationWithContext>;
+}
+
+#[derive(Debug)]
+struct Backend<TLocalLinter> {
+    client: Client,
+    local_linter: TLocalLinter,
+    per_file: DashMap<Url, PerFileState>,
+}
+
+impl<TLocalLinter: LocalLinter> Backend<TLocalLinter> {
+    pub fn new(client: Client, local_linter: TLocalLinter) -> Self {
+        Self {
+            client,
+            local_linter,
+            per_file: Default::default(),
+        }
+    }
+
+    async fn run_linting_and_report_diagnostics(&self, uri: &Url) {
+        let per_file_state = self.per_file.get(uri).unwrap();
+        let violations = self.local_linter.run_for_slice(
+            &per_file_state.contents,
+            Some(&per_file_state.tree),
+            "dummy_path",
+            Default::default(),
+        );
+        self.client
+            .publish_diagnostics(
+                uri.clone(),
+                violations
+                    .into_iter()
+                    .map(|violation| Diagnostic {
+                        message: violation.message,
+                        range: tree_sitter_range_to_lsp_range(
+                            &per_file_state.contents,
+                            violation.range,
+                        ),
+                        severity: Some(DiagnosticSeverity::ERROR),
+                        code: Some(NumberOrString::String(violation.rule.name)),
+                        source: Some("tree-sitter-lint".to_owned()),
+                        ..Default::default()
+                    })
+                    .collect(),
+                None,
+            )
+            .await;
+    }
+
+    async fn run_fixing_and_report_fixes(&self, uri: &Url) {
+        let per_file_state = self.per_file.get(uri).unwrap();
+        let mut cloned_contents = per_file_state.contents.clone();
+        self.local_linter.run_fixing_for_slice(
+            &mut cloned_contents,
+            Some(&per_file_state.tree),
+            "dummy_path",
+            ArgsBuilder::default().fix(true).build().unwrap(),
+        );
+        self.client
+            .apply_edit(WorkspaceEdit {
+                document_changes: Some(DocumentChanges::Edits(vec![get_text_document_edits(
+                    &per_file_state.contents,
+                    &cloned_contents,
+                    uri,
+                )])),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+    }
+}
+
+#[tower_lsp::async_trait]
+impl<TLocalLinter: LocalLinter + 'static> LanguageServer for Backend<TLocalLinter> {
+    async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
+        Ok(InitializeResult {
+            capabilities: ServerCapabilities {
+                text_document_sync: Some(TextDocumentSyncCapability::Kind(
+                    TextDocumentSyncKind::INCREMENTAL,
+                )),
+                execute_command_provider: Some(ExecuteCommandOptions {
+                    commands: vec![APPLY_ALL_FIXES_COMMAND.to_owned()],
+                    work_done_progress_options: Default::default(),
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+    }
+
+    async fn initialized(&self, _: InitializedParams) {
+        // self.client
+        //     .log_message(tower_lsp::lsp_types::MessageType::INFO, "server initialized!")
+        //     .await;
+    }
+
+    async fn shutdown(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn did_open(&self, params: DidOpenTextDocumentParams) {
+        let contents: Rope = (&*params.text_document.text).into();
+        self.per_file.insert(
+            params.text_document.uri.clone(),
+            PerFileState {
+                tree: parse_from_scratch(&contents),
+                contents,
+            },
+        );
+
+        self.run_linting_and_report_diagnostics(&params.text_document.uri)
+            .await;
+    }
+
+    async fn did_change(&self, params: DidChangeTextDocumentParams) {
+        {
+            let mut file_state = self
+                .per_file
+                .get_mut(&params.text_document.uri)
+                .expect("Changed file wasn't loaded");
+            for content_change in &params.content_changes {
+                match content_change.range {
+                    Some(range) => {
+                        let start_char =
+                            lsp_position_to_char_offset(&file_state.contents, range.start);
+                        let end_char = lsp_position_to_char_offset(&file_state.contents, range.end);
+                        let start_byte = file_state.contents.char_to_byte(start_char);
+                        let old_end_byte = file_state.contents.char_to_byte(end_char);
+                        file_state.contents.remove(start_char..end_char);
+                        file_state.contents.insert(start_char, &content_change.text);
+
+                        let new_end_byte = start_byte + content_change.text.len();
+                        let input_edit = InputEdit {
+                            start_byte,
+                            old_end_byte,
+                            new_end_byte,
+                            start_position: position_to_point(range.start),
+                            old_end_position: position_to_point(range.end),
+                            new_end_position: byte_offset_to_point(
+                                &file_state.contents,
+                                new_end_byte,
+                            ),
+                        };
+                        file_state.tree.edit(&input_edit);
+                        file_state.tree = parse(&file_state.contents, Some(&file_state.tree));
+                    }
+                    None => {
+                        file_state.contents = (&*content_change.text).into();
+                        file_state.tree = parse_from_scratch(&file_state.contents);
+                    }
+                }
+            }
+        }
+
+        self.run_linting_and_report_diagnostics(&params.text_document.uri)
+            .await;
+    }
+
+    async fn execute_command(
+        &self,
+        params: ExecuteCommandParams,
+    ) -> Result<Option<serde_json::Value>> {
+        match &*params.command {
+            APPLY_ALL_FIXES_COMMAND => {
+                self.run_fixing_and_report_fixes(&get_uri_from_arguments(&params.arguments))
+                    .await;
+            }
+            command => panic!("Unknown command: {:?}", command),
+        }
+
+        Ok(None)
+    }
+}
+
+#[derive(Debug)]
+struct PerFileState {
+    contents: Rope,
+    tree: Tree,
+}
+
+fn parse_from_scratch(contents: &Rope) -> Tree {
+    parse(contents, None)
+}
+
+fn parse(contents: &Rope, old_tree: Option<&Tree>) -> Tree {
+    let mut parser = Parser::new();
+    parser
+        .set_language(SupportedLanguage::Rust.language())
+        .unwrap();
+    contents.parse(&mut parser, old_tree).unwrap()
+}
+
+fn lsp_position_to_char_offset(file_contents: &Rope, position: Position) -> usize {
+    file_contents.line_to_char(position.line as usize) + position.character as usize
+}
+
+fn position_to_point(position: Position) -> Point {
+    Point {
+        row: position.line as usize,
+        column: position.character as usize,
+    }
+}
+
+fn point_to_position(point: Point) -> Position {
+    Position {
+        line: point.row as u32,
+        character: point.column as u32,
+    }
+}
+
+fn byte_offset_to_point(file_contents: &Rope, byte_offset: usize) -> Point {
+    let line_num = file_contents.byte_to_line(byte_offset);
+    let start_of_line_byte_offset = file_contents.line_to_byte(line_num);
+    Point {
+        row: line_num,
+        column: byte_offset - start_of_line_byte_offset,
+    }
+}
+
+fn byte_offset_to_position(file_contents: &Rope, byte_offset: usize) -> Position {
+    point_to_position(byte_offset_to_point(file_contents, byte_offset))
+}
+
+fn byte_offset_range_to_lsp_range(file_contents: &Rope, range: ops::Range<usize>) -> Range {
+    Range {
+        start: byte_offset_to_position(file_contents, range.start),
+        end: byte_offset_to_position(file_contents, range.end),
+    }
+}
+
+fn tree_sitter_range_to_lsp_range(file_contents: &Rope, range: tree_sitter::Range) -> Range {
+    byte_offset_range_to_lsp_range(file_contents, range.start_byte..range.end_byte)
+}
+
+fn get_text_document_edits(
+    old_contents: &Rope,
+    new_contents: &Rope,
+    uri: &Url,
+) -> TextDocumentEdit {
+    let old_contents_as_str: Cow<'_, str> = old_contents.clone().into();
+    let new_contents_as_str: Cow<'_, str> = new_contents.clone().into();
+    let (_, diffs) = text_diff::diff(&old_contents_as_str, &new_contents_as_str, "");
+    let mut old_bytes_seen = 0;
+    let mut just_seen_remove: Option<String> = None;
+    let mut edits: Vec<TextEdit> = Default::default();
+    for diff in diffs {
+        if just_seen_remove.is_some() && !matches!(&diff, Difference::Add(_)) {
+            edits.push(TextEdit {
+                range: byte_offset_range_to_lsp_range(
+                    old_contents,
+                    old_bytes_seen - just_seen_remove.as_ref().unwrap().len()..old_bytes_seen,
+                ),
+                new_text: Default::default(),
+            });
+            just_seen_remove = None;
+        }
+        match diff {
+            Difference::Same(diff) => old_bytes_seen += diff.len(),
+            Difference::Rem(diff) => {
+                old_bytes_seen += diff.len();
+                just_seen_remove = Some(diff);
+            }
+            Difference::Add(diff) => {
+                if just_seen_remove.is_some() {
+                    edits.push(TextEdit {
+                        range: byte_offset_range_to_lsp_range(
+                            old_contents,
+                            old_bytes_seen - just_seen_remove.as_ref().unwrap().len()
+                                ..old_bytes_seen,
+                        ),
+                        new_text: diff,
+                    });
+                    just_seen_remove = None;
+                } else {
+                    edits.push(TextEdit {
+                        range: byte_offset_range_to_lsp_range(
+                            old_contents,
+                            old_bytes_seen..old_bytes_seen,
+                        ),
+                        new_text: diff,
+                    });
+                }
+            }
+        }
+    }
+    if let Some(just_seen_remove) = just_seen_remove.as_ref() {
+        edits.push(TextEdit {
+            range: byte_offset_range_to_lsp_range(
+                old_contents,
+                old_bytes_seen..old_bytes_seen + just_seen_remove.len(),
+            ),
+            new_text: Default::default(),
+        });
+    }
+    TextDocumentEdit {
+        text_document: OptionalVersionedTextDocumentIdentifier {
+            uri: uri.clone(),
+            version: None,
+        },
+        edits: edits.into_iter().map(OneOf::Left).collect(),
+    }
+}
+
+fn get_uri_from_arguments(arguments: &[serde_json::Value]) -> Url {
+    if arguments.len() != 1 {
+        panic!("Expected to get passed a single file description");
+    }
+    match &arguments[0] {
+        serde_json::Value::Object(map) => map["uri"].as_str().unwrap().try_into().unwrap(),
+        _ => panic!("Expected file description to be object"),
+    }
+}
+
+pub async fn run<TLocalLinter: LocalLinter + 'static>(local_linter: TLocalLinter) {
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+
+    let (service, socket) = LspService::new(|client| Backend::new(client, local_linter));
+    Server::new(stdin, stdout, socket).serve(service).await;
+}


### PR DESCRIPTION
In this PR:
- move [tree-sitter-lint-lsp](https://github.com/helixbass/tree-sitter-lint-lsp) into this repo
- update local-project code generation to be "back in sync" with the committed custom local binary project
- also include/generate an LSP server binary in that local project

To test:
If you either touch the `.tree-sitter-lint.yml` config file or run eg `cargo build --force-rebuild` it should re-generate the local project in `.tree-sitter-lint/tree-sitter-lint-local/` and re-compile a working release binary (of the `tree-sitter-lint-local` binary)
It's not currently also release-building the local LSP server binary at that time because it looked like that one was significantly slower to release-build so didn't want to "slow down" the command-line re-generation use case - I guess the LSP server "shell" would take responsibility for doing the release-build'ing of the local LSP server binaries at appropriate times?
But so for now you could manually run eg `cargo build --release --bin tree-sitter-lint-local-lsp` from `.tree-sitter-lint/tree-sitter-lint-local/` and that should successfully build a custom LSP server binary that then if you were eg able to run some LSP stuff in the `tree-sitter-lint-lsp` PR's you should still be able to run using that generated binary

Based on `split-config`