### PR TITLE
Support per-match query callback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,7 @@ clap = "4.3.17"
 derive_builder = "0.12.0"
 proc_macros = { package = "tree_sitter_lint_proc_macros", path = "proc_macros", version = "0.0.1-dev.0" }
 regex = "1.9.1"
-# tree-sitter-grep = { package = "tree_sitter_lint_tree-sitter-grep", git = "https://github.com/helixbass/tree-sitter-grep", rev = "672ac41", version = "0.1.0" }
-tree-sitter-grep = { package = "tree_sitter_lint_tree-sitter-grep", path = "../tree-sitter-grep" }
+tree-sitter-grep = { package = "tree_sitter_lint_tree-sitter-grep", git = "https://github.com/helixbass/tree-sitter-grep", rev = "c5f3fa2", version = "0.1.0" }
 rayon = "1.7.0"
 serde = "1.0.175"
 serde_yaml = "0.9.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ clap = "4.3.17"
 derive_builder = "0.12.0"
 proc_macros = { package = "tree_sitter_lint_proc_macros", path = "proc_macros", version = "0.0.1-dev.0" }
 regex = "1.9.1"
-tree-sitter-grep = { package = "tree_sitter_lint_tree-sitter-grep", git = "https://github.com/helixbass/tree-sitter-grep", rev = "672ac41", version = "0.1.0" }
+# tree-sitter-grep = { package = "tree_sitter_lint_tree-sitter-grep", git = "https://github.com/helixbass/tree-sitter-grep", rev = "672ac41", version = "0.1.0" }
+tree-sitter-grep = { package = "tree_sitter_lint_tree-sitter-grep", path = "../tree-sitter-grep" }
 rayon = "1.7.0"
 serde = "1.0.175"
 serde_yaml = "0.9.25"

--- a/proc_macros/src/rule.rs
+++ b/proc_macros/src/rule.rs
@@ -444,7 +444,9 @@ fn get_rule_rule_impl(
                     listener_queries: vec![
                         #(#crate_name::RuleListenerQuery {
                             query: #rule_listener_queries.into(),
-                            capture_name: #rule_listener_capture_names,
+                            match_by: #crate_name::MatchBy::PerCapture {
+                                capture_name: #rule_listener_capture_names,
+                            },
                         }),*
                     ],
                     #(#rule_instance_state_field_names: #rule_instance_state_field_initializers),*
@@ -619,7 +621,11 @@ fn get_rule_instance_per_file_rule_instance_per_file_impl(
     });
     quote! {
         impl #crate_name::RuleInstancePerFile for #rule_instance_per_file_struct_name {
-            fn on_query_match(&mut self, listener_index: usize, node: #crate_name::tree_sitter::Node, context: &mut #crate_name::QueryMatchContext) {
+            fn on_query_match(&mut self, listener_index: usize, node_or_captures: #crate_name::NodeOrCaptures, context: &mut #crate_name::QueryMatchContext) {
+                let node = match node_or_captures {
+                    #crate_name::NodeOrCaptures::Node(node) => node,
+                    _ => panic!("Expected node"),
+                };
                 match listener_index {
                     #(#listener_indices => {
                         #listener_callbacks


### PR DESCRIPTION
In this PR:
- In order to support rule listeners that would really like to "capture multiple different nodes from a single query match", adjust so that per-rule-listener it can either be "individual-capture-oriented" or "match-oriented" (in terms of the "granularity" with which we invoke the rule listener callback and what it receives as arguments to that callback)

To test:
Per the added test if you're using the `rule!()` macro and have a rule listener with multiple (different) `@whatever`'s and make the listener callback take `captures` as its first param, you should be able to access all of those matched capture nodes for each time the overall query matches

Based on `use-rule-languages`