### PR TITLE
Violation message ID's/data

### DIFF
--- a/proc_macros/src/lib.rs
+++ b/proc_macros/src/lib.rs
@@ -4,9 +4,11 @@ mod builder_args;
 mod helpers;
 mod rule;
 mod rule_tests;
+mod violation;
 
 use helpers::ArrowSeparatedKeyValuePairs;
 use rule::rule_with_crate_name;
+use violation::violation_with_crate_name;
 
 #[proc_macro]
 pub fn builder_args(input: TokenStream) -> TokenStream {
@@ -31,4 +33,14 @@ pub fn rule(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn rule_crate_internal(input: TokenStream) -> TokenStream {
     rule_with_crate_name(input, "crate")
+}
+
+#[proc_macro]
+pub fn violation(input: TokenStream) -> TokenStream {
+    violation_with_crate_name(input, "tree_sitter_lint")
+}
+
+#[proc_macro]
+pub fn violation_crate_internal(input: TokenStream) -> TokenStream {
+    violation_with_crate_name(input, "crate")
 }

--- a/proc_macros/src/lib.rs
+++ b/proc_macros/src/lib.rs
@@ -4,6 +4,7 @@ mod builder_args;
 mod helpers;
 mod rule;
 mod rule_tests;
+mod shared;
 mod violation;
 
 use helpers::ArrowSeparatedKeyValuePairs;

--- a/proc_macros/src/rule_tests.rs
+++ b/proc_macros/src/rule_tests.rs
@@ -3,7 +3,7 @@ use quote::{format_ident, quote, ToTokens};
 use syn::{
     braced, bracketed,
     parse::{Parse, ParseStream},
-    parse_macro_input, token, Expr, ExprArray, Ident, Token,
+    parse_macro_input, token, Expr, Ident, Token,
 };
 
 struct RuleOptions {
@@ -84,9 +84,128 @@ impl ToTokens for ValidRuleTestSpec {
     }
 }
 
+enum InvalidRuleTestErrorSpec {
+    Fields {
+        message: Option<Expr>,
+        line: Option<Expr>,
+        column: Option<Expr>,
+        end_line: Option<Expr>,
+        end_column: Option<Expr>,
+        type_: Option<Expr>,
+    },
+    Expr(Expr),
+}
+
+impl Parse for InvalidRuleTestErrorSpec {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(if input.peek(token::Brace) {
+            let error_content;
+            braced!(error_content in input);
+            let mut message: Option<Expr> = Default::default();
+            let mut line: Option<Expr> = Default::default();
+            let mut column: Option<Expr> = Default::default();
+            let mut end_line: Option<Expr> = Default::default();
+            let mut end_column: Option<Expr> = Default::default();
+            let mut type_: Option<Expr> = Default::default();
+            while !error_content.is_empty() {
+                let key: Ident = error_content.parse()?;
+                error_content.parse::<Token![=>]>()?;
+                match &*key.to_string() {
+                    "message" => {
+                        message = Some(error_content.parse()?);
+                    }
+                    "line" => {
+                        line = Some(error_content.parse()?);
+                    }
+                    "column" => {
+                        column = Some(error_content.parse()?);
+                    }
+                    "end_line" => {
+                        end_line = Some(error_content.parse()?);
+                    }
+                    "end_column" => {
+                        end_column = Some(error_content.parse()?);
+                    }
+                    "type_" => {
+                        type_ = Some(error_content.parse()?);
+                    }
+                    _ => panic!("didn't expect key '{}'", key),
+                }
+                if !error_content.is_empty() {
+                    error_content.parse::<Token![,]>()?;
+                }
+            }
+            Self::Fields {
+                message,
+                line,
+                column,
+                end_line,
+                end_column,
+                type_,
+            }
+        } else {
+            Self::Expr(input.parse()?)
+        })
+    }
+}
+
+impl ToTokens for InvalidRuleTestErrorSpec {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        match self {
+            Self::Fields {
+                message,
+                line,
+                column,
+                end_line,
+                end_column,
+                type_,
+            } => {
+                let message = match message.as_ref() {
+                    Some(message) => quote!(Some(#message.into())),
+                    None => quote!(None),
+                };
+                let line = match line.as_ref() {
+                    Some(line) => quote!(Some(#line)),
+                    None => quote!(None),
+                };
+                let column = match column.as_ref() {
+                    Some(column) => quote!(Some(#column)),
+                    None => quote!(None),
+                };
+                let end_line = match end_line.as_ref() {
+                    Some(end_line) => quote!(Some(#end_line)),
+                    None => quote!(None),
+                };
+                let end_column = match end_column.as_ref() {
+                    Some(end_column) => quote!(Some(#end_column)),
+                    None => quote!(None),
+                };
+                let type_ = match type_.as_ref() {
+                    Some(type_) => quote!(Some(#type_)),
+                    None => quote!(None),
+                };
+                quote! {
+                    tree_sitter_lint::RuleTestExpectedError {
+                        message: #message,
+                        line: #line,
+                        column: #column,
+                        end_line: #end_line,
+                        end_column: #end_column,
+                        type_: #type_,
+                    }
+                }
+            }
+            Self::Expr(expr) => {
+                quote!(tree_sitter_lint::RuleTestExpectedError::from(#expr))
+            }
+        }
+        .to_tokens(tokens)
+    }
+}
+
 struct InvalidRuleTestSpec {
     code: Expr,
-    errors: ExprArray,
+    errors: Vec<InvalidRuleTestErrorSpec>,
     output: Option<Expr>,
     options: Option<RuleOptions>,
 }
@@ -94,7 +213,7 @@ struct InvalidRuleTestSpec {
 impl Parse for InvalidRuleTestSpec {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let mut code: Option<Expr> = Default::default();
-        let mut errors: Option<ExprArray> = Default::default();
+        let mut errors: Option<Vec<InvalidRuleTestErrorSpec>> = Default::default();
         let mut output: Option<Expr> = Default::default();
         let mut options: Option<RuleOptions> = Default::default();
         let content;
@@ -107,7 +226,15 @@ impl Parse for InvalidRuleTestSpec {
                     code = Some(content.parse()?);
                 }
                 "errors" => {
-                    errors = Some(content.parse()?);
+                    let errors_content;
+                    bracketed!(errors_content in content);
+                    let errors = errors.get_or_insert_with(|| Default::default());
+                    while !errors_content.is_empty() {
+                        errors.push(errors_content.parse()?);
+                        if !errors_content.is_empty() {
+                            errors_content.parse::<Token![,]>()?;
+                        }
+                    }
                 }
                 "output" => {
                     output = Some(content.parse()?);
@@ -133,7 +260,7 @@ impl Parse for InvalidRuleTestSpec {
 impl ToTokens for InvalidRuleTestSpec {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         let code = &self.code;
-        let errors = &self.errors;
+        let errors = self.errors.iter().map(|error| quote!(#error));
         let output = match self.output.as_ref() {
             Some(output) => quote! {
                 Some(#output)
@@ -151,7 +278,7 @@ impl ToTokens for InvalidRuleTestSpec {
         quote! {
             tree_sitter_lint::RuleTestInvalid::new(
                 #code,
-                #errors,
+                vec![#(#errors),*],
                 #output,
                 #options
             )
@@ -192,9 +319,7 @@ impl Parse for RuleTests {
                     bracketed!(invalid_content in input);
                     let invalid = invalid.get_or_insert_with(|| Default::default());
                     while !invalid_content.is_empty() {
-                        let invalid_rule_test_spec: InvalidRuleTestSpec =
-                            invalid_content.parse()?;
-                        invalid.push(invalid_rule_test_spec);
+                        invalid.push(invalid_content.parse()?);
                         if !invalid_content.is_empty() {
                             invalid_content.parse::<Token![,]>()?;
                         }

--- a/proc_macros/src/rule_tests.rs
+++ b/proc_macros/src/rule_tests.rs
@@ -5,7 +5,9 @@ use quote::{format_ident, quote, ToTokens};
 use syn::{
     braced, bracketed,
     parse::{Parse, ParseStream},
-    parse_macro_input, token, Expr, Ident, Token,
+    parse_macro_input,
+    spanned::Spanned,
+    token, Expr, Ident, Token,
 };
 
 struct RuleOptions {
@@ -86,6 +88,33 @@ impl ToTokens for ValidRuleTestSpec {
     }
 }
 
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+enum ExprOrIdent {
+    Expr(Expr),
+    Ident(Ident),
+}
+
+impl ToTokens for ExprOrIdent {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        match self {
+            Self::Expr(expr) => expr.to_tokens(tokens),
+            Self::Ident(ident) => ident.to_tokens(tokens),
+        }
+    }
+}
+
+impl From<Expr> for ExprOrIdent {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
+
+impl From<Ident> for ExprOrIdent {
+    fn from(value: Ident) -> Self {
+        Self::Ident(value)
+    }
+}
+
 enum InvalidRuleTestErrorSpec {
     Fields {
         message: Option<Expr>,
@@ -95,7 +124,7 @@ enum InvalidRuleTestErrorSpec {
         end_column: Option<Expr>,
         type_: Option<Expr>,
         message_id: Option<Expr>,
-        data: Option<HashMap<Expr, Expr>>,
+        data: Option<HashMap<ExprOrIdent, Expr>>,
     },
     Expr(Expr),
 }
@@ -112,7 +141,7 @@ impl Parse for InvalidRuleTestErrorSpec {
             let mut end_column: Option<Expr> = Default::default();
             let mut type_: Option<Expr> = Default::default();
             let mut message_id: Option<Expr> = Default::default();
-            let mut data: Option<HashMap<Expr, Expr>> = Default::default();
+            let mut data: Option<HashMap<ExprOrIdent, Expr>> = Default::default();
             while !error_content.is_empty() {
                 let key: Result<Ident, _> = error_content.parse();
                 let key = match key {
@@ -158,7 +187,17 @@ impl Parse for InvalidRuleTestErrorSpec {
                         if error_content.peek(token::Brace) {
                             braced!(data_content in error_content);
                             while !data_content.is_empty() {
-                                let key: Expr = data_content.parse()?;
+                                let key: Result<Expr, _> = data_content.parse();
+                                let key: ExprOrIdent = match key {
+                                    Ok(key) => Ok(key.into()),
+                                    Err(err) => {
+                                        if let Ok(key) = data_content.parse::<Token![type]>() {
+                                            Ok(Ident::new("type_", key.span()).into())
+                                        } else {
+                                            Err(err)
+                                        }
+                                    }
+                                }?;
                                 data_content.parse::<Token![=>]>()?;
                                 let value: Expr = data_content.parse()?;
                                 data.insert(key, value);
@@ -169,7 +208,17 @@ impl Parse for InvalidRuleTestErrorSpec {
                         } else {
                             bracketed!(data_content in error_content);
                             while !data_content.is_empty() {
-                                let key: Expr = data_content.parse()?;
+                                let key: Result<Expr, _> = data_content.parse();
+                                let key: ExprOrIdent = match key {
+                                    Ok(key) => Ok(key.into()),
+                                    Err(err) => {
+                                        if let Ok(key) = data_content.parse::<Token![type]>() {
+                                            Ok(Ident::new("type_", key.span()).into())
+                                        } else {
+                                            Err(err)
+                                        }
+                                    }
+                                }?;
                                 data_content.parse::<Token![=>]>()?;
                                 let value: Expr = data_content.parse()?;
                                 data.insert(key, value);
@@ -245,7 +294,8 @@ impl ToTokens for InvalidRuleTestErrorSpec {
                 let data = match data.as_ref() {
                     Some(data) => {
                         let data_keys = data.keys().map(|key| match key {
-                            Expr::Path(key) if key.path.get_ident().is_some() => {
+                            ExprOrIdent::Ident(key) => quote!(stringify!(#key)),
+                            ExprOrIdent::Expr(Expr::Path(key)) if key.path.get_ident().is_some() => {
                                 quote!(stringify!(#key))
                             }
                             _ => quote!(#key),

--- a/proc_macros/src/shared.rs
+++ b/proc_macros/src/shared.rs
@@ -1,0 +1,80 @@
+use std::collections::HashMap;
+
+use quote::ToTokens;
+use syn::{braced, bracketed, parse::ParseStream, spanned::Spanned, token, Expr, Ident, Token};
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum ExprOrIdent {
+    Expr(Expr),
+    Ident(Ident),
+}
+
+impl ToTokens for ExprOrIdent {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        match self {
+            Self::Expr(expr) => expr.to_tokens(tokens),
+            Self::Ident(ident) => ident.to_tokens(tokens),
+        }
+    }
+}
+
+impl From<Expr> for ExprOrIdent {
+    fn from(value: Expr) -> Self {
+        Self::Expr(value)
+    }
+}
+
+impl From<Ident> for ExprOrIdent {
+    fn from(value: Ident) -> Self {
+        Self::Ident(value)
+    }
+}
+
+pub fn parse_data(data: &mut HashMap<ExprOrIdent, Expr>, input: ParseStream) -> syn::Result<()> {
+    let data_content;
+    if input.peek(token::Brace) {
+        braced!(data_content in input);
+        while !data_content.is_empty() {
+            let key: Result<Expr, _> = data_content.parse();
+            let key: ExprOrIdent = match key {
+                Ok(key) => Ok(key.into()),
+                Err(err) => {
+                    if let Ok(key) = data_content.parse::<Token![type]>() {
+                        Ok(Ident::new("type_", key.span()).into())
+                    } else {
+                        Err(err)
+                    }
+                }
+            }?;
+            data_content.parse::<Token![=>]>()?;
+            let value: Expr = data_content.parse()?;
+            data.insert(key, value);
+            if !data_content.is_empty() {
+                data_content.parse::<Token![,]>()?;
+            }
+        }
+    } else {
+        bracketed!(data_content in input);
+        while !data_content.is_empty() {
+            let key: Result<Expr, _> = data_content.parse();
+            let key: ExprOrIdent = match key {
+                Ok(key) => Ok(key.into()),
+                Err(err) => {
+                    if let Ok(key) = data_content.parse::<Token![type]>() {
+                        Ok(Ident::new("type_", key.span()).into())
+                    } else {
+                        Err(err)
+                    }
+                }
+            }?;
+            data_content.parse::<Token![=>]>()?;
+            let value: Expr = data_content.parse()?;
+            data.insert(key, value);
+            if !data_content.is_empty() {
+                data_content.parse::<Token![,]>()?;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/proc_macros/src/violation.rs
+++ b/proc_macros/src/violation.rs
@@ -98,7 +98,10 @@ pub fn violation_with_crate_name(input: TokenStream, crate_name: &str) -> TokenS
 
     let data = match violation.data.as_ref() {
         Some(data) => {
-            let data_keys = data.keys();
+            let data_keys = data.keys().map(|key| match key {
+                Expr::Path(key) if key.path.get_ident().is_some() => quote!(stringify!(#key)),
+                _ => quote!(#key),
+            });
             let data_values = data.values();
             quote! {
                 .data([#((String::from(#data_keys), String::from(#data_values))),*])

--- a/proc_macros/src/violation.rs
+++ b/proc_macros/src/violation.rs
@@ -1,0 +1,122 @@
+use std::collections::HashMap;
+
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{
+    braced,
+    parse::{Parse, ParseStream},
+    parse_macro_input, Expr, Ident, Token,
+};
+
+struct Violation {
+    message: Option<Expr>,
+    message_id: Option<Expr>,
+    node: Expr,
+    fix: Option<Expr>,
+    data: Option<HashMap<Expr, Expr>>,
+}
+
+impl Parse for Violation {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut message: Option<Expr> = Default::default();
+        let mut message_id: Option<Expr> = Default::default();
+        let mut node: Option<Expr> = Default::default();
+        let mut fix: Option<Expr> = Default::default();
+        let mut data: Option<HashMap<Expr, Expr>> = Default::default();
+
+        while !input.is_empty() {
+            let key: Ident = input.parse()?;
+            input.parse::<Token![=>]>()?;
+            match &*key.to_string() {
+                "message" => {
+                    assert!(message.is_none(), "Already saw 'message'");
+                    message = Some(input.parse()?);
+                }
+                "message_id" => {
+                    assert!(message_id.is_none(), "Already saw 'message_id'");
+                    message_id = Some(input.parse()?);
+                }
+                "node" => {
+                    assert!(node.is_none(), "Already saw 'node'");
+                    node = Some(input.parse()?);
+                }
+                "fix" => {
+                    assert!(fix.is_none(), "Already saw 'fix'");
+                    fix = Some(input.parse()?);
+                }
+                "data" => {
+                    assert!(data.is_none(), "Already saw 'data'");
+                    let data = data.get_or_insert_with(Default::default);
+                    let data_content;
+                    braced!(data_content in input);
+                    while !data_content.is_empty() {
+                        let key: Expr = data_content.parse()?;
+                        data_content.parse::<Token![=>]>()?;
+                        let value: Expr = data_content.parse()?;
+                        data.insert(key, value);
+                        if !data_content.is_empty() {
+                            data_content.parse::<Token![,]>()?;
+                        }
+                    }
+                }
+                _ => panic!("Unexpected key: '{key}'"),
+            }
+            if !input.is_empty() {
+                input.parse::<Token![,]>()?;
+            }
+        }
+
+        Ok(Self {
+            message,
+            message_id,
+            node: node.expect("Expected 'node' key"),
+            fix,
+            data,
+        })
+    }
+}
+
+pub fn violation_with_crate_name(input: TokenStream, crate_name: &str) -> TokenStream {
+    let violation: Violation = parse_macro_input!(input);
+
+    let crate_name = format_ident!("{}", crate_name);
+
+    let message = match violation.message.as_ref() {
+        Some(message) => quote!(.message(#message)),
+        None => quote!(),
+    };
+
+    let message_id = match violation.message_id.as_ref() {
+        Some(message_id) => quote!(.message_id(#message_id)),
+        None => quote!(),
+    };
+
+    let fix = match violation.fix.as_ref() {
+        Some(fix) => quote!(.fix(#fix)),
+        None => quote!(),
+    };
+
+    let data = match violation.data.as_ref() {
+        Some(data) => {
+            let data_keys = data.keys();
+            let data_values = data.values();
+            quote! {
+                .data([#((String::from(#data_keys), String::from(#data_values))),*])
+            }
+        }
+        None => quote!(),
+    };
+
+    let node = &violation.node;
+
+    quote! {
+        #crate_name::ViolationBuilder::default()
+            #message
+            #message_id
+            #fix
+            .node(#node)
+            #data
+            .build().unwrap()
+    }
+    .into()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub use config::{Args, ArgsBuilder, Config, ConfigBuilder, RuleConfiguration};
 use context::PendingFix;
 pub use context::QueryMatchContext;
 pub use plugin::Plugin;
-pub use proc_macros::{builder_args, rule, rule_tests};
+pub use proc_macros::{builder_args, rule, rule_tests, violation};
 use rayon::prelude::*;
 use rule::{Captures, InstantiatedRule};
 pub use rule::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,10 @@ pub use rule::{
     FileRunInfo, MatchBy, NodeOrCaptures, Rule, RuleInstance, RuleInstancePerFile,
     RuleListenerQuery, RuleMeta,
 };
-pub use rule_tester::{RuleTestInvalid, RuleTestValid, RuleTester, RuleTests};
+pub use rule_tester::{
+    RuleTestExpectedError, RuleTestExpectedErrorBuilder, RuleTestInvalid, RuleTestValid,
+    RuleTester, RuleTests,
+};
 pub use slice::MutRopeOrSlice;
 use tree_sitter::{Query, Tree};
 use tree_sitter_grep::{tree_sitter::QueryMatch, RopeOrSlice, SupportedLanguage};

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -75,7 +75,7 @@ impl<TLocalLinter: LocalLinter> Backend<TLocalLinter> {
                 violations
                     .into_iter()
                     .map(|violation| Diagnostic {
-                        message: violation.message,
+                        message: violation.message().into_owned(),
                         range: tree_sitter_range_to_lsp_range(
                             &per_file_state.contents,
                             violation.range,

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -1,4 +1,4 @@
-use std::{ops, sync::Arc};
+use std::{collections::HashMap, ops, sync::Arc};
 
 use tree_sitter_grep::{tree_sitter::QueryMatch, SupportedLanguage};
 
@@ -14,6 +14,7 @@ pub struct RuleMeta {
     pub name: String,
     pub fixable: bool,
     pub languages: Vec<SupportedLanguage>,
+    pub messages: Option<HashMap<String, String>>,
 }
 
 pub trait Rule: Send + Sync {

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -9,7 +9,7 @@ use crate::{
     Config,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct RuleMeta {
     pub name: String,
     pub fixable: bool,

--- a/src/rule_tester.rs
+++ b/src/rule_tester.rs
@@ -1,4 +1,4 @@
-use std::{iter, sync::Arc};
+use std::{collections::HashMap, iter, sync::Arc};
 
 use derive_builder::Builder;
 use tree_sitter_grep::SupportedLanguage;
@@ -6,7 +6,7 @@ use tree_sitter_grep::SupportedLanguage;
 use crate::{
     config::{ConfigBuilder, ErrorLevel},
     rule::{Rule, RuleOptions},
-    violation::ViolationWithContext,
+    violation::{MessageOrMessageId, ViolationWithContext},
     RuleConfiguration,
 };
 
@@ -140,6 +140,17 @@ fn assert_that_violation_matches_expected(
     if let Some(type_) = expected_violation.type_.as_ref() {
         assert_eq!(type_, violation.kind);
     }
+    if let Some(message_id) = expected_violation.message_id.as_ref() {
+        match &violation.message_or_message_id {
+            MessageOrMessageId::MessageId(violation_message_id) => {
+                assert_eq!(violation_message_id, message_id);
+            }
+            _ => panic!("Expected violation to use message ID"),
+        }
+    }
+    if let Some(data) = expected_violation.data.as_ref() {
+        assert_eq!(Some(data), violation.data.as_ref());
+    }
 }
 
 pub struct RuleTests {
@@ -212,6 +223,8 @@ pub struct RuleTestExpectedError {
     pub end_line: Option<usize>,
     pub end_column: Option<usize>,
     pub type_: Option<String>,
+    pub message_id: Option<String>,
+    pub data: Option<HashMap<String, String>>,
 }
 
 impl RuleTestExpectedError {

--- a/src/rule_tester.rs
+++ b/src/rule_tester.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, iter, sync::Arc};
+use std::{iter, sync::Arc};
 
 use derive_builder::Builder;
 use tree_sitter_grep::SupportedLanguage;
@@ -6,7 +6,7 @@ use tree_sitter_grep::SupportedLanguage;
 use crate::{
     config::{ConfigBuilder, ErrorLevel},
     rule::{Rule, RuleOptions},
-    violation::{MessageOrMessageId, ViolationWithContext},
+    violation::{MessageOrMessageId, ViolationData, ViolationWithContext},
     RuleConfiguration,
 };
 
@@ -224,7 +224,7 @@ pub struct RuleTestExpectedError {
     pub end_column: Option<usize>,
     pub type_: Option<String>,
     pub message_id: Option<String>,
-    pub data: Option<HashMap<String, String>>,
+    pub data: Option<ViolationData>,
 }
 
 impl RuleTestExpectedError {

--- a/src/rule_tester.rs
+++ b/src/rule_tester.rs
@@ -123,7 +123,7 @@ fn assert_that_violation_matches_expected(
     expected_violation: &RuleTestExpectedError,
 ) {
     if let Some(message) = expected_violation.message.as_ref() {
-        assert_eq!(message, &violation.message);
+        assert_eq!(message, &violation.message());
     }
     if let Some(line) = expected_violation.line {
         assert_eq!(line, violation.range.start_point.row + 1);

--- a/src/tests/fixing.rs
+++ b/src/tests/fixing.rs
@@ -2,9 +2,9 @@
 
 use std::sync::Arc;
 
-use proc_macros::rule_crate_internal as rule;
+use proc_macros::{rule_crate_internal as rule, violation_crate_internal as violation};
 
-use crate::{rule::Rule, violation};
+use crate::rule::Rule;
 
 #[macro_export]
 macro_rules! assert_fixed_content {

--- a/src/tests/rules.rs
+++ b/src/tests/rules.rs
@@ -311,3 +311,51 @@ fn test_rule_one_off_messages_interpolated() {
         },
     );
 }
+
+#[test]
+fn test_rule_tests_message_id_and_data() {
+    RuleTester::run(
+        rule! {
+            name => "has-interpolated-message",
+            messages => [
+                foo => "Interpolated {{ foo }}",
+            ],
+            listeners => [
+                r#"(
+                  (function_item) @c
+                )"# => |node, context| {
+                    context.report(violation! {
+                        node => node,
+                        message_id => "foo",
+                        data => {
+                            foo => "bar",
+                        }
+                    });
+                }
+            ],
+            languages => [Rust],
+        },
+        rule_tests! {
+            valid => [
+                r#"
+                    use foo::bar;
+                "#,
+            ],
+            invalid => [
+                {
+                    code => r#"
+                        fn whee() {}
+                    "#,
+                    errors => [
+                        {
+                            message_id => "foo",
+                            data => [
+                                foo => "bar",
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
+    );
+}

--- a/src/tests/rules.rs
+++ b/src/tests/rules.rs
@@ -2,9 +2,12 @@
 
 use std::sync::Arc;
 
-use proc_macros::{rule_crate_internal as rule, rule_tests_crate_internal as rule_tests};
+use proc_macros::{
+    rule_crate_internal as rule, rule_tests_crate_internal as rule_tests,
+    violation_crate_internal as violation,
+};
 
-use crate::{rule::Rule, violation, RuleTester};
+use crate::{rule::Rule, RuleTester};
 
 #[test]
 fn test_per_file_run_state() {

--- a/src/tests/rules.rs
+++ b/src/tests/rules.rs
@@ -194,3 +194,82 @@ fn test_rule_per_match_callback() {
         },
     );
 }
+
+#[test]
+fn test_rule_messages_non_interpolated() {
+    RuleTester::run(
+        rule! {
+            name => "has-non-interpolated-message",
+            messages => [
+                non_interpolated => "Not interpolated",
+            ],
+            listeners => [
+                r#"(
+                  (function_item) @c
+                )"# => |node, context| {
+                    context.report(violation! {
+                        node => node,
+                        message_id => "non_interpolated",
+                    });
+                }
+            ],
+            languages => [Rust],
+        },
+        rule_tests! {
+            valid => [
+                r#"
+                    use foo::bar;
+                "#,
+            ],
+            invalid => [
+                {
+                    code => r#"
+                        fn whee() {}
+                    "#,
+                    errors => [r#"Not interpolated"#],
+                },
+            ]
+        },
+    );
+}
+
+#[test]
+fn test_rule_messages_interpolated() {
+    RuleTester::run(
+        rule! {
+            name => "has-interpolated-message",
+            messages => [
+                interpolated => "Interpolated {{ foo }}",
+            ],
+            listeners => [
+                r#"(
+                  (function_item) @c
+                )"# => |node, context| {
+                    context.report(violation! {
+                        node => node,
+                        message_id => "interpolated",
+                        data => {
+                            foo => "bar"
+                        }
+                    });
+                }
+            ],
+            languages => [Rust],
+        },
+        rule_tests! {
+            valid => [
+                r#"
+                    use foo::bar;
+                "#,
+            ],
+            invalid => [
+                {
+                    code => r#"
+                        fn whee() {}
+                    "#,
+                    errors => [r#"Interpolated bar"#],
+                },
+            ]
+        },
+    );
+}

--- a/src/tests/rules.rs
+++ b/src/tests/rules.rs
@@ -273,3 +273,41 @@ fn test_rule_messages_interpolated() {
         },
     );
 }
+
+#[test]
+fn test_rule_one_off_messages_interpolated() {
+    RuleTester::run(
+        rule! {
+            name => "has-interpolated-message",
+            listeners => [
+                r#"(
+                  (function_item) @c
+                )"# => |node, context| {
+                    context.report(violation! {
+                        node => node,
+                        message => "Interpolated {{ foo }}",
+                        data => {
+                            foo => "bar"
+                        }
+                    });
+                }
+            ],
+            languages => [Rust],
+        },
+        rule_tests! {
+            valid => [
+                r#"
+                    use foo::bar;
+                "#,
+            ],
+            invalid => [
+                {
+                    code => r#"
+                        fn whee() {}
+                    "#,
+                    errors => [r#"Interpolated bar"#],
+                },
+            ]
+        },
+    );
+}

--- a/src/violation.rs
+++ b/src/violation.rs
@@ -105,19 +105,17 @@ impl ViolationWithContext {
     }
 
     pub fn message(&self) -> Cow<'_, str> {
-        match &self.message_or_message_id {
-            MessageOrMessageId::Message(message) => message.into(),
-            MessageOrMessageId::MessageId(message_id) => {
-                let message_template = self
-                    .rule
-                    .messages
-                    .as_ref()
-                    .expect("No messages for rule")
-                    .get(message_id)
-                    .unwrap_or_else(|| panic!("Invalid message ID for rule: {message_id:?}"));
-                format_message(message_template, self.data.as_ref())
-            }
-        }
+        let message_template = match &self.message_or_message_id {
+            MessageOrMessageId::Message(message) => message,
+            MessageOrMessageId::MessageId(message_id) => self
+                .rule
+                .messages
+                .as_ref()
+                .expect("No messages for rule")
+                .get(message_id)
+                .unwrap_or_else(|| panic!("Invalid message ID for rule: {message_id:?}")),
+        };
+        format_message(message_template, self.data.as_ref())
     }
 }
 

--- a/src/violation.rs
+++ b/src/violation.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, rc::Rc};
+use std::{borrow::Cow, collections::HashMap, path::PathBuf, rc::Rc};
 
 use derive_builder::Builder;
 
@@ -11,13 +11,15 @@ use crate::{
 };
 
 #[derive(Builder)]
-#[builder(setter(into))]
+#[builder(setter(into, strip_option))]
 pub struct Violation<'a> {
-    pub message: String,
+    pub message_or_message_id: MessageOrMessageId,
     pub node: Node<'a>,
     #[allow(clippy::type_complexity)]
     #[builder(default, setter(custom))]
     pub fix: Option<Rc<dyn Fn(&mut Fixer) + 'a>>,
+    #[builder(default)]
+    pub data: Option<ViolationData>,
 }
 
 impl<'a> Violation<'a> {
@@ -25,15 +27,21 @@ impl<'a> Violation<'a> {
         self,
         query_match_context: &QueryMatchContext<'a>,
     ) -> ViolationWithContext {
-        let Violation { message, node, fix } = self;
+        let Violation {
+            message_or_message_id,
+            node,
+            fix,
+            data,
+        } = self;
         ViolationWithContext {
-            message,
+            message_or_message_id,
             range: node.range(),
             kind: node.kind(),
             path: query_match_context.path.to_owned(),
             rule: query_match_context.rule.meta.clone(),
             plugin_index: query_match_context.rule.plugin_index,
             was_fix: fix.is_some(),
+            data,
         }
     }
 }
@@ -43,17 +51,38 @@ impl<'a> ViolationBuilder<'a> {
         self.fix = Some(Some(Rc::new(callback)));
         self
     }
+
+    pub fn message(&mut self, message: impl Into<String>) -> &mut Self {
+        let message = message.into();
+        self.message_or_message_id = Some(MessageOrMessageId::Message(message));
+        self
+    }
+
+    pub fn message_id(&mut self, message_id: impl Into<String>) -> &mut Self {
+        let message_id = message_id.into();
+        self.message_or_message_id = Some(MessageOrMessageId::MessageId(message_id));
+        self
+    }
 }
 
 #[derive(Clone, Debug)]
+pub enum MessageOrMessageId {
+    Message(String),
+    MessageId(String),
+}
+
+pub type ViolationData = HashMap<String, String>;
+
+#[derive(Clone, Debug)]
 pub struct ViolationWithContext {
-    pub message: String,
+    pub message_or_message_id: MessageOrMessageId,
     pub range: tree_sitter::Range,
     pub path: PathBuf,
     pub rule: RuleMeta,
     pub plugin_index: Option<PluginIndex>,
     pub was_fix: bool,
     pub kind: &'static str,
+    pub data: Option<ViolationData>,
 }
 
 impl ViolationWithContext {
@@ -63,7 +92,7 @@ impl ViolationWithContext {
             self.path,
             self.range.start_point.row + 1,
             self.range.start_point.column + 1,
-            self.message,
+            self.message(),
             match self.plugin_index {
                 None => self.rule.name.clone(),
                 Some(plugin_index) => format!(
@@ -74,14 +103,44 @@ impl ViolationWithContext {
             }
         );
     }
+
+    pub fn message(&self) -> Cow<'_, str> {
+        match &self.message_or_message_id {
+            MessageOrMessageId::Message(message) => message.into(),
+            MessageOrMessageId::MessageId(message_id) => {
+                let message_template = self
+                    .rule
+                    .messages
+                    .as_ref()
+                    .expect("No messages for rule")
+                    .get(message_id)
+                    .unwrap_or_else(|| panic!("Invalid message ID for rule: {message_id:?}"));
+                format_message(message_template, self.data.as_ref())
+            }
+        }
+    }
 }
 
-#[macro_export]
-macro_rules! violation {
-    ($($variant:ident => $value:expr),* $(,)?) => {
-        $crate::builder_args!(
-            $crate::ViolationBuilder,
-            $($variant => $value),*,
-        )
+fn format_message<'a>(message_template: &'a str, data: Option<&ViolationData>) -> Cow<'a, str> {
+    let mut formatted: Option<String> = Default::default();
+    let mut unprocessed = message_template;
+    while let Some(interpolation_offset) = unprocessed.find("{{") {
+        let formatted = formatted.get_or_insert_with(Default::default);
+        formatted.push_str(&unprocessed[..interpolation_offset]);
+        unprocessed = &unprocessed[interpolation_offset + 2..];
+        let end_interpolation_offset = unprocessed.find("}}").expect("No matching `}}` in message");
+        let interpolated_name = unprocessed[..end_interpolation_offset].trim();
+        let value = data
+            .expect("No data provided for interpolated message")
+            .get(interpolated_name)
+            .unwrap_or_else(|| panic!("Didn't provide expected data key {interpolated_name:?}"));
+        formatted.push_str(value);
+        unprocessed = &unprocessed[end_interpolation_offset + 2..];
     }
+    formatted
+        .map(|mut formatted| {
+            formatted.push_str(unprocessed);
+            formatted
+        })
+        .map_or_else(|| message_template.into(), Into::into)
 }

--- a/src/violation.rs
+++ b/src/violation.rs
@@ -29,6 +29,7 @@ impl<'a> Violation<'a> {
         ViolationWithContext {
             message,
             range: node.range(),
+            kind: node.kind(),
             path: query_match_context.path.to_owned(),
             rule: query_match_context.rule.meta.clone(),
             plugin_index: query_match_context.rule.plugin_index,
@@ -44,7 +45,7 @@ impl<'a> ViolationBuilder<'a> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ViolationWithContext {
     pub message: String,
     pub range: tree_sitter::Range,
@@ -52,6 +53,7 @@ pub struct ViolationWithContext {
     pub rule: RuleMeta,
     pub plugin_index: Option<PluginIndex>,
     pub was_fix: bool,
+    pub kind: &'static str,
 }
 
 impl ViolationWithContext {


### PR DESCRIPTION
In this PR:
- add support for rules declaring known "messages" by "message ID" key and violations/rule tests referring to those message ID's (vs "hard-coding" "one-off" string messages)
- support both "one-off" + known violation messages being "interpolated" (via `{{ key }}` syntax) with an expected passed `data` key-value blob on the violation

To test:
Per added tests, you should be able to use these known messages/interpolation in rules/rule tests

Based on `per-match-callback`