### PR TITLE
Tokens iterator

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -63,7 +63,7 @@ impl<'a> QueryMatchContext<'a> {
             .push(violation);
     }
 
-    pub fn get_node_text(&self, node: Node) -> &str {
+    pub fn get_node_text(&self, node: Node) -> &'a str {
         match &self.file_contents {
             RopeOrSlice::Slice(file_contents) => node.utf8_text(file_contents).unwrap(),
             RopeOrSlice::Rope(_) => unimplemented!(),

--- a/src/context.rs
+++ b/src/context.rs
@@ -134,6 +134,14 @@ impl<'a> QueryMatchContext<'a> {
     pub fn into_pending_fixes(self) -> Option<Vec<PendingFix>> {
         self.pending_fixes
     }
+
+    pub fn has_named_child_of_kind(&self, node: Node, kind: &str) -> bool {
+        let mut cursor = node.walk();
+        let ret = node
+            .named_children(&mut cursor)
+            .any(|child| child.kind() == kind);
+        ret
+    }
 }
 
 pub enum ParsedOrUnparsedQuery<'a> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,6 +1,8 @@
 use std::{ops, path::Path};
 
-use tree_sitter_grep::{streaming_iterator::StreamingIterator, RopeOrSlice, SupportedLanguage};
+use tree_sitter_grep::{
+    streaming_iterator::StreamingIterator, tree_sitter::TreeCursor, RopeOrSlice, SupportedLanguage,
+};
 
 use crate::{
     rule::InstantiatedRule,
@@ -64,10 +66,7 @@ impl<'a> QueryMatchContext<'a> {
     }
 
     pub fn get_node_text(&self, node: Node) -> &'a str {
-        match &self.file_contents {
-            RopeOrSlice::Slice(file_contents) => node.utf8_text(file_contents).unwrap(),
-            RopeOrSlice::Rope(_) => unimplemented!(),
-        }
+        get_node_text(node, self.file_contents)
     }
 
     pub fn maybe_get_single_captured_node_for_query<'query, 'enclosing_node>(
@@ -141,6 +140,10 @@ impl<'a> QueryMatchContext<'a> {
             .named_children(&mut cursor)
             .any(|child| child.kind() == kind);
         ret
+    }
+
+    pub fn get_tokens(&self, node: Node<'a>) -> impl Iterator<Item = Node<'a>> {
+        get_tokens(node)
     }
 }
 
@@ -240,5 +243,171 @@ pub struct PendingFix {
 impl PendingFix {
     pub fn new(range: ops::Range<usize>, replacement: String) -> Self {
         Self { range, replacement }
+    }
+}
+
+fn get_node_text<'a>(node: Node, file_contents: RopeOrSlice<'a>) -> &'a str {
+    match file_contents {
+        RopeOrSlice::Slice(file_contents) => node.utf8_text(file_contents).unwrap(),
+        RopeOrSlice::Rope(_) => unimplemented!(),
+    }
+}
+
+macro_rules! move_to_next_sibling_or_go_to_parent_and_loop {
+    ($self:expr) => {
+        if !$self.cursor.goto_next_sibling() {
+            $self.cursor.goto_parent();
+            $self.state = JustReturnedToParent;
+            continue;
+        }
+    };
+}
+
+macro_rules! loop_if_on_comment {
+    ($self:expr) => {
+        if $self.cursor.node().kind() == "comment" {
+            $self.state = OnComment;
+            continue;
+        }
+    };
+}
+
+macro_rules! loop_landed_on_node {
+    ($self:expr) => {
+        $self.state = LandedOnNonCommentNode;
+        continue;
+    };
+}
+
+macro_rules! loop_done {
+    ($self:expr) => {
+        $self.state = Done;
+        continue;
+    };
+}
+
+fn get_tokens(node: Node) -> impl Iterator<Item = Node> {
+    TokenWalker::new(node)
+}
+
+struct TokenWalker<'a> {
+    state: TokenWalkerState,
+    cursor: TreeCursor<'a>,
+    original_node: Node<'a>,
+}
+
+impl<'a> TokenWalker<'a> {
+    pub fn new(node: Node<'a>) -> Self {
+        Self {
+            state: TokenWalkerState::Initial,
+            cursor: node.walk(),
+            original_node: node,
+        }
+    }
+}
+
+impl<'a> Iterator for TokenWalker<'a> {
+    type Item = Node<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        use TokenWalkerState::*;
+
+        loop {
+            match self.state {
+                Done => {
+                    return None;
+                }
+                Initial => {
+                    if self.cursor.node().kind() == "comment" {
+                        loop_done!(self);
+                    }
+                    if !self.cursor.goto_first_child() {
+                        self.state = Done;
+                        return Some(self.cursor.node());
+                    }
+                    loop_landed_on_node!(self);
+                }
+                ReturnedCurrentNode => {
+                    move_to_next_sibling_or_go_to_parent_and_loop!(self);
+                    loop_if_on_comment!(self);
+                    loop_landed_on_node!(self);
+                }
+                OnComment => {
+                    move_to_next_sibling_or_go_to_parent_and_loop!(self);
+                    loop_if_on_comment!(self);
+                    loop_landed_on_node!(self);
+                }
+                LandedOnNonCommentNode => {
+                    if !self.cursor.goto_first_child() {
+                        self.state = ReturnedCurrentNode;
+                        return Some(self.cursor.node());
+                    }
+                    loop_if_on_comment!(self);
+                    loop_landed_on_node!(self);
+                }
+                JustReturnedToParent => {
+                    if self.cursor.node() == self.original_node {
+                        loop_done!(self);
+                    }
+                    move_to_next_sibling_or_go_to_parent_and_loop!(self);
+                    loop_if_on_comment!(self);
+                    loop_landed_on_node!(self);
+                }
+            }
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum TokenWalkerState {
+    Initial,
+    OnComment,
+    ReturnedCurrentNode,
+    JustReturnedToParent,
+    LandedOnNonCommentNode,
+    Done,
+}
+
+#[cfg(test)]
+mod tests {
+    use tree_sitter_grep::tree_sitter::Parser;
+
+    use super::*;
+
+    fn test_all_tokens_text(text: &str, all_tokens_text: &[&str]) {
+        let mut parser = Parser::new();
+        parser
+            .set_language(SupportedLanguage::Javascript.language())
+            .unwrap();
+        let tree = parser.parse(text, None).unwrap();
+        assert_eq!(
+            get_tokens(tree.root_node())
+                .map(|node| node.utf8_text(text.as_bytes()).unwrap())
+                .collect::<Vec<_>>(),
+            all_tokens_text
+        );
+    }
+
+    #[test]
+    fn test_get_tokens_simple() {
+        test_all_tokens_text("const x = 5;", &["const", "x", "=", "5", ";"]);
+    }
+
+    #[test]
+    fn test_get_tokens_structured() {
+        test_all_tokens_text(
+            r#"
+            const whee = function(foo) {
+                for (let x = 1; x < 100; x++) {
+                    foo(x);
+                }
+            }
+        "#,
+            &[
+                "const", "whee", "=", "function", "(", "foo", ")", "{", "for", "(", "let", "x",
+                "=", "1", ";", "x", "<", "100", ";", "x", "++", ")", "{", "foo", "(", "x", ")",
+                ";", "}", "}",
+            ],
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,8 +36,8 @@ pub use rule::{
     RuleListenerQuery, RuleMeta,
 };
 pub use rule_tester::{
-    RuleTestExpectedError, RuleTestExpectedErrorBuilder, RuleTestInvalid, RuleTestValid,
-    RuleTester, RuleTests,
+    RuleTestExpectedError, RuleTestExpectedErrorBuilder, RuleTestExpectedOutput, RuleTestInvalid,
+    RuleTestValid, RuleTester, RuleTests,
 };
 pub use slice::MutRopeOrSlice;
 use tree_sitter::{Query, Tree};

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -75,6 +75,7 @@ impl<'a> From<Captures<'a>> for NodeOrCaptures<'a> {
     }
 }
 
+#[derive(Debug)]
 pub struct Captures<'a> {
     pub query_match: &'a QueryMatch<'a, 'a>,
     pub query: Arc<Query>,
@@ -96,7 +97,7 @@ impl<'a> Captures<'a> {
         Some(first_node)
     }
 
-    pub fn all(&self, capture_name: &str) -> impl Iterator<Item = Node> {
+    pub fn get_all(&self, capture_name: &str) -> impl Iterator<Item = Node> {
         self.query_match
             .nodes_for_capture_index(self.query.capture_index_for_name(capture_name).unwrap())
     }


### PR DESCRIPTION
In this PR:
- a couple things to support the ESLint rules plugin, including the ability to iterate over the individual "tokens" of a tree-sitter AST node

To test:
Per the added tests if you call `context.get_tokens()` you should see expected individual "leaf" node/"tokens" (not including comments)

Based on `invalid-rule-test-error-fields`