### PR TITLE
Options type ergonomics

### DIFF
--- a/.tree-sitter-lint/local_rules/src/rules/prefer_impl_param.rs
+++ b/.tree-sitter-lint/local_rules/src/rules/prefer_impl_param.rs
@@ -102,7 +102,7 @@ pub fn prefer_impl_param_rule() -> Arc<dyn Rule> {
                 let type_identifier_query =
                     query!(
                         r#"(type_identifier) @c"#,
-                        context.language.language(),
+                        context.language().language(),
                     );
                 return_if_none!(context.maybe_get_single_captured_node_for_filtered_query(
                     type_identifier_query,

--- a/proc_macros/src/rule.rs
+++ b/proc_macros/src/rule.rs
@@ -577,7 +577,7 @@ fn get_rule_instance_rule_instance_impl(
         impl #crate_name::RuleInstance for #rule_instance_struct_name {
             fn instantiate_per_file<'a>(
                 self: std::sync::Arc<Self>,
-                _file_run_info: &#crate_name::FileRunInfo<'a>,
+                _file_run_context: #crate_name::FileRunContext<'a>,
             ) -> Box<dyn #crate_name::RuleInstancePerFile<'a> + 'a> {
                 Box::new(#rule_instance_per_file_struct_name {
                     rule_instance: self,

--- a/src/aggregated_queries.rs
+++ b/src/aggregated_queries.rs
@@ -1,0 +1,131 @@
+use std::{collections::HashMap, sync::Arc};
+
+use tree_sitter_grep::{tree_sitter::Query, SupportedLanguage};
+
+use crate::{
+    rule::{InstantiatedRule, ResolvedMatchBy},
+    ROOT_EXIT,
+};
+
+type RuleIndex = usize;
+type RuleListenerIndex = usize;
+type CaptureIndexIfPerCapture = Option<u32>;
+
+pub struct AggregatedQueriesPerLanguage {
+    pub pattern_index_lookup: Vec<(RuleIndex, RuleListenerIndex, CaptureIndexIfPerCapture)>,
+    pub query: Arc<Query>,
+    #[allow(dead_code)]
+    pub query_text: String,
+}
+
+#[derive(Default)]
+struct AggregatedQueriesPerLanguageBuilder {
+    pattern_index_lookup: Vec<(RuleIndex, RuleListenerIndex, CaptureIndexIfPerCapture)>,
+    query_text: String,
+}
+
+impl AggregatedQueriesPerLanguageBuilder {
+    pub fn build(self, language: SupportedLanguage) -> AggregatedQueriesPerLanguage {
+        let Self {
+            pattern_index_lookup,
+            query_text,
+        } = self;
+        let query = Arc::new(Query::new(language.language(), &query_text).unwrap());
+        assert!(query.pattern_count() == pattern_index_lookup.len());
+        AggregatedQueriesPerLanguage {
+            pattern_index_lookup,
+            query,
+            query_text,
+        }
+    }
+}
+
+pub struct AggregatedQueries<'a> {
+    pub instantiated_rules: &'a [InstantiatedRule],
+    pub per_language: HashMap<SupportedLanguage, AggregatedQueriesPerLanguage>,
+    pub instantiated_rule_root_exit_rule_listener_indices: HashMap<usize, usize>,
+}
+
+impl<'a> AggregatedQueries<'a> {
+    pub fn new(instantiated_rules: &'a [InstantiatedRule]) -> Self {
+        let mut per_language: HashMap<SupportedLanguage, AggregatedQueriesPerLanguageBuilder> =
+            Default::default();
+        let mut instantiated_rule_root_exit_rule_listener_indices: HashMap<usize, usize> =
+            Default::default();
+        for (rule_index, instantiated_rule) in instantiated_rules.into_iter().enumerate() {
+            for &language in &instantiated_rule.meta.languages {
+                let per_language_builder = per_language.entry(language).or_default();
+                for (rule_listener_index, rule_listener_query) in instantiated_rule
+                    .rule_instance
+                    .listener_queries()
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(rule_listener_index, rule_listener_query)| {
+                        if rule_listener_query.query == ROOT_EXIT {
+                            instantiated_rule_root_exit_rule_listener_indices
+                                .insert(rule_index, rule_listener_index);
+
+                            return None;
+                        }
+
+                        Some((
+                            rule_listener_index,
+                            rule_listener_query.resolve(language.language()),
+                        ))
+                    })
+                {
+                    let capture_index_if_per_capture: CaptureIndexIfPerCapture =
+                        match &rule_listener_query.match_by {
+                            ResolvedMatchBy::PerCapture { capture_index } => Some(*capture_index),
+                            _ => None,
+                        };
+
+                    for _ in 0..rule_listener_query.query.pattern_count() {
+                        per_language_builder.pattern_index_lookup.push((
+                            rule_index,
+                            rule_listener_index,
+                            capture_index_if_per_capture,
+                        ));
+                    }
+                    per_language_builder
+                        .query_text
+                        .push_str(&rule_listener_query.query_text);
+                    per_language_builder.query_text.push_str("\n\n");
+                }
+            }
+        }
+
+        Self {
+            instantiated_rules,
+            per_language: per_language
+                .into_iter()
+                .map(|(language, per_language_value)| {
+                    (language, per_language_value.build(language))
+                })
+                .collect(),
+            instantiated_rule_root_exit_rule_listener_indices,
+        }
+    }
+
+    pub fn get_rule_and_listener_index_and_capture_index(
+        &self,
+        language: SupportedLanguage,
+        pattern_index: usize,
+    ) -> (&'a InstantiatedRule, usize, CaptureIndexIfPerCapture) {
+        let (rule_index, rule_listener_index, capture_index_if_per_capture) = self
+            .per_language
+            .get(&language)
+            .unwrap()
+            .pattern_index_lookup[pattern_index];
+        let instantiated_rule = &self.instantiated_rules[rule_index];
+        (
+            instantiated_rule,
+            rule_listener_index,
+            capture_index_if_per_capture,
+        )
+    }
+
+    pub fn get_query_for_language(&self, language: SupportedLanguage) -> Arc<Query> {
+        self.per_language.get(&language).unwrap().query.clone()
+    }
+}

--- a/src/context/fix.rs
+++ b/src/context/fix.rs
@@ -1,0 +1,57 @@
+use std::ops;
+
+use squalid::{IsEmpty, OptionExt};
+use tree_sitter_grep::tree_sitter::Node;
+
+#[derive(Default)]
+pub struct Fixer {
+    pending_fixes: Option<Vec<PendingFix>>,
+}
+
+impl Fixer {
+    pub fn replace_text(&mut self, node: Node, replacement: impl Into<String>) {
+        self.pending_fixes
+            .get_or_insert_with(Default::default)
+            .push(PendingFix::new(node.byte_range(), replacement.into()));
+    }
+
+    pub(crate) fn into_pending_fixes(self) -> Option<Vec<PendingFix>> {
+        self.pending_fixes
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.pending_fixes
+            .as_ref()
+            .is_none_or_matches(|pending_fixes| pending_fixes.is_empty())
+    }
+
+    pub fn remove_range(&mut self, range: ops::Range<usize>) {
+        self.pending_fixes
+            .get_or_insert_with(Default::default)
+            .push(PendingFix::new(range, Default::default()));
+    }
+
+    pub fn replace_text_range(&mut self, range: ops::Range<usize>, replacement: impl Into<String>) {
+        self.pending_fixes
+            .get_or_insert_with(Default::default)
+            .push(PendingFix::new(range, replacement.into()));
+    }
+}
+
+impl IsEmpty for Fixer {
+    fn _is_empty(&self) -> bool {
+        self.is_empty()
+    }
+}
+
+#[derive(Clone)]
+pub struct PendingFix {
+    pub range: ops::Range<usize>,
+    pub replacement: String,
+}
+
+impl PendingFix {
+    pub fn new(range: ops::Range<usize>, replacement: String) -> Self {
+        Self { range, replacement }
+    }
+}

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -302,6 +302,11 @@ impl<'a> QueryMatchContext<'a> {
                     }
             })
     }
+
+    pub fn get_comments_after(&self, node: Node<'a>) -> impl Iterator<Item = Node<'a>> {
+        let comment_kinds = self.language.comment_kinds();
+        get_tokens_after_node(node).take_while(|node| comment_kinds.contains(node.kind()))
+    }
 }
 
 #[derive(Builder)]

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -3,6 +3,7 @@ use std::{
     cell::{Ref, RefCell},
     ops,
     path::Path,
+    sync::Arc,
 };
 
 use tree_sitter_grep::{
@@ -23,7 +24,7 @@ use crate::{
     rule::InstantiatedRule,
     tree_sitter::{Language, Node, Query},
     violation::{Violation, ViolationWithContext},
-    Config,
+    AggregatedQueries, Config,
 };
 
 #[derive(Copy, Clone)]
@@ -33,15 +34,22 @@ pub struct FileRunContext<'a> {
     pub tree: &'a Tree,
     pub config: &'a Config,
     pub language: SupportedLanguage,
+    pub(crate) aggregated_queries: &'a AggregatedQueries<'a>,
+    pub(crate) query: &'a Arc<Query>,
+    pub(crate) instantiated_rules: &'a [InstantiatedRule],
 }
 
 impl<'a> FileRunContext<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         path: &'a Path,
         file_contents: impl Into<RopeOrSlice<'a>>,
         tree: &'a Tree,
         config: &'a Config,
         language: SupportedLanguage,
+        aggregated_queries: &'a AggregatedQueries,
+        query: &'a Arc<Query>,
+        instantiated_rules: &'a [InstantiatedRule],
     ) -> Self {
         let file_contents = file_contents.into();
         Self {
@@ -50,6 +58,9 @@ impl<'a> FileRunContext<'a> {
             tree,
             config,
             language,
+            aggregated_queries,
+            query,
+            instantiated_rules,
         }
     }
 }

--- a/src/context/skip_options.rs
+++ b/src/context/skip_options.rs
@@ -1,0 +1,54 @@
+use derive_builder::Builder;
+use tree_sitter_grep::tree_sitter::Node;
+
+#[derive(Builder)]
+#[builder(default, setter(strip_option))]
+pub struct SkipOptions<TFilter: FnMut(Node) -> bool> {
+    skip: Option<usize>,
+    include_comments: Option<bool>,
+    filter: Option<TFilter>,
+}
+
+impl<TFilter: FnMut(Node) -> bool> SkipOptions<TFilter> {
+    pub fn skip(&self) -> usize {
+        self.skip.unwrap_or_default()
+    }
+
+    pub fn include_comments(&self) -> bool {
+        self.include_comments.unwrap_or_default()
+    }
+
+    pub fn filter(&mut self) -> Option<&mut TFilter> {
+        self.filter.as_mut()
+    }
+}
+
+impl<TFilter: FnMut(Node) -> bool> Default for SkipOptions<TFilter> {
+    fn default() -> Self {
+        Self {
+            skip: Default::default(),
+            include_comments: Default::default(),
+            filter: Default::default(),
+        }
+    }
+}
+
+impl From<usize> for SkipOptions<fn(Node) -> bool> {
+    fn from(value: usize) -> Self {
+        Self {
+            skip: Some(value),
+            include_comments: Default::default(),
+            filter: Default::default(),
+        }
+    }
+}
+
+impl<TFilter: FnMut(Node) -> bool> From<TFilter> for SkipOptions<TFilter> {
+    fn from(value: TFilter) -> Self {
+        Self {
+            skip: Default::default(),
+            include_comments: Default::default(),
+            filter: Some(value),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::into_iter_on_ref)]
 
+mod aggregated_queries;
 mod cli;
 mod config;
 mod context;
@@ -22,9 +23,10 @@ use std::{
     ops::Deref,
     path::{Path, PathBuf},
     process,
-    sync::{Arc, Mutex, PoisonError},
+    sync::{Mutex, PoisonError},
 };
 
+use aggregated_queries::AggregatedQueries;
 pub use cli::bootstrap_cli;
 pub use config::{Args, ArgsBuilder, Config, ConfigBuilder, RuleConfiguration};
 use context::PendingFix;
@@ -43,7 +45,7 @@ pub use rule_tester::{
     RuleTestValid, RuleTester, RuleTests,
 };
 pub use slice::MutRopeOrSlice;
-use tree_sitter::{Query, Tree};
+use tree_sitter::Tree;
 use tree_sitter_grep::{
     get_matches, get_parser, streaming_iterator::StreamingIterator, tree_sitter::QueryMatch,
     Parseable, RopeOrSlice, SupportedLanguage,
@@ -56,8 +58,6 @@ pub extern crate serde_yaml;
 pub extern crate tokio;
 pub extern crate tree_sitter_grep;
 pub use tree_sitter_grep::{ropey, tree_sitter};
-
-use crate::rule::ResolvedMatchBy;
 
 pub fn run_and_output(config: Config) {
     let violations = run(&config);
@@ -72,28 +72,24 @@ pub fn run_and_output(config: Config) {
 
 const MAX_FIX_ITERATIONS: usize = 10;
 
-#[allow(clippy::too_many_arguments)]
 fn run_per_file<'a>(
     file_run_context: FileRunContext<'a>,
-    aggregated_queries: &'a AggregatedQueries<'a>,
     mut on_found_violations: impl FnMut(Vec<ViolationWithContext>),
     mut on_found_pending_fixes: impl FnMut(Vec<PendingFix>, &InstantiatedRule),
-    query: &'a Arc<Query>,
-    instantiated_rules: &'a [InstantiatedRule],
 ) {
     let mut instantiated_per_file_rules: HashMap<RuleName, Box<dyn RuleInstancePerFile<'a> + 'a>> =
         Default::default();
     get_matches(
         file_run_context.language.language(),
         file_run_context.file_contents,
-        query,
+        file_run_context.query,
         Some(file_run_context.tree),
     )
     .for_each(|query_match| {
         run_match(
             file_run_context,
             query_match,
-            aggregated_queries,
+            file_run_context.aggregated_queries,
             &mut instantiated_per_file_rules,
             &mut on_found_violations,
             |pending_fixes, instantiated_rule| {
@@ -102,18 +98,22 @@ fn run_per_file<'a>(
         );
     });
 
-    for (&instantiated_rule_index, &rule_listener_index) in
-        &aggregated_queries.instantiated_rule_root_exit_rule_listener_indices
+    for (&instantiated_rule_index, &rule_listener_index) in &file_run_context
+        .aggregated_queries
+        .instantiated_rule_root_exit_rule_listener_indices
     {
         run_single_on_query_match_callback(
             file_run_context,
-            &instantiated_rules[instantiated_rule_index],
+            &file_run_context.instantiated_rules[instantiated_rule_index],
             &mut instantiated_per_file_rules,
             rule_listener_index,
             file_run_context.tree.root_node().into(),
             &mut on_found_violations,
             |pending_fixes| {
-                on_found_pending_fixes(pending_fixes, &instantiated_rules[instantiated_rule_index])
+                on_found_pending_fixes(
+                    pending_fixes,
+                    &file_run_context.instantiated_rules[instantiated_rule_index],
+                )
             },
         );
     }
@@ -129,8 +129,16 @@ pub fn run(config: &Config) -> Vec<ViolationWithContext> {
         tree_sitter_grep_args,
         |dir_entry, language, file_contents, tree, query| {
             run_per_file(
-                FileRunContext::new(dir_entry.path(), file_contents, tree, config, language),
-                &aggregated_queries,
+                FileRunContext::new(
+                    dir_entry.path(),
+                    file_contents,
+                    tree,
+                    config,
+                    language,
+                    &aggregated_queries,
+                    query,
+                    &instantiated_rules,
+                ),
                 |violations| {
                     all_violations
                         .lock()
@@ -148,8 +156,6 @@ pub fn run(config: &Config) -> Vec<ViolationWithContext> {
                         language,
                     )
                 },
-                query,
-                &instantiated_rules,
             );
         },
     )
@@ -251,7 +257,6 @@ fn run_match<'a, 'b>(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn run_single_on_query_match_callback<'a, 'b>(
     file_run_context: FileRunContext<'a>,
     instantiated_rule: &'a InstantiatedRule,
@@ -313,8 +318,20 @@ fn run_fixing_loop<'a>(
             .parse(&mut get_parser(language.language()), None)
             .unwrap();
         run_per_file(
-            FileRunContext::new(path, &file_contents, &tree, config, language),
-            aggregated_queries,
+            FileRunContext::new(
+                path,
+                &file_contents,
+                &tree,
+                config,
+                language,
+                aggregated_queries,
+                &aggregated_queries
+                    .per_language
+                    .get(&language)
+                    .unwrap()
+                    .query,
+                instantiated_rules,
+            ),
             |reported_violations| {
                 violations.extend(reported_violations);
             },
@@ -324,12 +341,6 @@ fn run_fixing_loop<'a>(
                     .or_default()
                     .extend(fixes);
             },
-            &aggregated_queries
-                .per_language
-                .get(&language)
-                .unwrap()
-                .query,
-            instantiated_rules,
         );
         if pending_fixes.is_empty() {
             break;
@@ -363,20 +374,26 @@ pub fn run_for_slice<'a>(
         Cow::Borrowed,
     );
     run_per_file(
-        FileRunContext::new(path, file_contents, &tree, &config, language),
-        &aggregated_queries,
+        FileRunContext::new(
+            path,
+            file_contents,
+            &tree,
+            &config,
+            language,
+            &aggregated_queries,
+            &aggregated_queries
+                .per_language
+                .get(&language)
+                .unwrap()
+                .query,
+            &instantiated_rules,
+        ),
         |reported_violations| {
             violations.lock().unwrap().extend(reported_violations);
         },
         |_, _| {
             panic!("Expected no fixes");
         },
-        &aggregated_queries
-            .per_language
-            .get(&language)
-            .unwrap()
-            .query,
-        &instantiated_rules,
     );
     violations.into_inner().unwrap()
 }
@@ -408,8 +425,20 @@ pub fn run_fixing_for_slice<'a>(
     let violations: Mutex<Vec<ViolationWithContext>> = Default::default();
     let pending_fixes: Mutex<HashMap<RuleName, Vec<PendingFix>>> = Default::default();
     run_per_file(
-        FileRunContext::new(path, &file_contents, &tree, &config, language),
-        &aggregated_queries,
+        FileRunContext::new(
+            path,
+            &file_contents,
+            &tree,
+            &config,
+            language,
+            &aggregated_queries,
+            &aggregated_queries
+                .per_language
+                .get(&language)
+                .unwrap()
+                .query,
+            &instantiated_rules,
+        ),
         |reported_violations| {
             violations.lock().unwrap().extend(reported_violations);
         },
@@ -421,12 +450,6 @@ pub fn run_fixing_for_slice<'a>(
                 .or_default()
                 .extend(fixes);
         },
-        &aggregated_queries
-            .per_language
-            .get(&language)
-            .unwrap()
-            .query,
-        &instantiated_rules,
     );
     let mut violations = violations.into_inner().unwrap();
     let pending_fixes = pending_fixes.into_inner().unwrap();
@@ -586,128 +609,5 @@ impl PerFilePendingFixes {
             pending_fixes: Default::default(),
             language,
         }
-    }
-}
-
-type RuleIndex = usize;
-type RuleListenerIndex = usize;
-type CaptureIndexIfPerCapture = Option<u32>;
-
-struct AggregatedQueriesPerLanguage {
-    pattern_index_lookup: Vec<(RuleIndex, RuleListenerIndex, CaptureIndexIfPerCapture)>,
-    query: Arc<Query>,
-    #[allow(dead_code)]
-    query_text: String,
-}
-
-#[derive(Default)]
-struct AggregatedQueriesPerLanguageBuilder {
-    pattern_index_lookup: Vec<(RuleIndex, RuleListenerIndex, CaptureIndexIfPerCapture)>,
-    query_text: String,
-}
-
-impl AggregatedQueriesPerLanguageBuilder {
-    pub fn build(self, language: SupportedLanguage) -> AggregatedQueriesPerLanguage {
-        let Self {
-            pattern_index_lookup,
-            query_text,
-        } = self;
-        let query = Arc::new(Query::new(language.language(), &query_text).unwrap());
-        assert!(query.pattern_count() == pattern_index_lookup.len());
-        AggregatedQueriesPerLanguage {
-            pattern_index_lookup,
-            query,
-            query_text,
-        }
-    }
-}
-
-struct AggregatedQueries<'a> {
-    instantiated_rules: &'a [InstantiatedRule],
-    per_language: HashMap<SupportedLanguage, AggregatedQueriesPerLanguage>,
-    pub instantiated_rule_root_exit_rule_listener_indices: HashMap<usize, usize>,
-}
-
-impl<'a> AggregatedQueries<'a> {
-    pub fn new(instantiated_rules: &'a [InstantiatedRule]) -> Self {
-        let mut per_language: HashMap<SupportedLanguage, AggregatedQueriesPerLanguageBuilder> =
-            Default::default();
-        let mut instantiated_rule_root_exit_rule_listener_indices: HashMap<usize, usize> =
-            Default::default();
-        for (rule_index, instantiated_rule) in instantiated_rules.into_iter().enumerate() {
-            for &language in &instantiated_rule.meta.languages {
-                let per_language_builder = per_language.entry(language).or_default();
-                for (rule_listener_index, rule_listener_query) in instantiated_rule
-                    .rule_instance
-                    .listener_queries()
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(rule_listener_index, rule_listener_query)| {
-                        if rule_listener_query.query == ROOT_EXIT {
-                            instantiated_rule_root_exit_rule_listener_indices
-                                .insert(rule_index, rule_listener_index);
-
-                            return None;
-                        }
-
-                        Some((
-                            rule_listener_index,
-                            rule_listener_query.resolve(language.language()),
-                        ))
-                    })
-                {
-                    let capture_index_if_per_capture: CaptureIndexIfPerCapture =
-                        match &rule_listener_query.match_by {
-                            ResolvedMatchBy::PerCapture { capture_index } => Some(*capture_index),
-                            _ => None,
-                        };
-
-                    for _ in 0..rule_listener_query.query.pattern_count() {
-                        per_language_builder.pattern_index_lookup.push((
-                            rule_index,
-                            rule_listener_index,
-                            capture_index_if_per_capture,
-                        ));
-                    }
-                    per_language_builder
-                        .query_text
-                        .push_str(&rule_listener_query.query_text);
-                    per_language_builder.query_text.push_str("\n\n");
-                }
-            }
-        }
-
-        Self {
-            instantiated_rules,
-            per_language: per_language
-                .into_iter()
-                .map(|(language, per_language_value)| {
-                    (language, per_language_value.build(language))
-                })
-                .collect(),
-            instantiated_rule_root_exit_rule_listener_indices,
-        }
-    }
-
-    pub fn get_rule_and_listener_index_and_capture_index(
-        &self,
-        language: SupportedLanguage,
-        pattern_index: usize,
-    ) -> (&'a InstantiatedRule, usize, CaptureIndexIfPerCapture) {
-        let (rule_index, rule_listener_index, capture_index_if_per_capture) = self
-            .per_language
-            .get(&language)
-            .unwrap()
-            .pattern_index_lookup[pattern_index];
-        let instantiated_rule = &self.instantiated_rules[rule_index];
-        (
-            instantiated_rule,
-            rule_listener_index,
-            capture_index_if_per_capture,
-        )
-    }
-
-    pub fn get_query_for_language(&self, language: SupportedLanguage) -> Arc<Query> {
-        self.per_language.get(&language).unwrap().query.clone()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ use std::{
 pub use cli::bootstrap_cli;
 pub use config::{Args, ArgsBuilder, Config, ConfigBuilder, RuleConfiguration};
 use context::PendingFix;
-pub use context::QueryMatchContext;
+pub use context::{QueryMatchContext, SkipOptions, SkipOptionsBuilder};
 pub use node::NodeExt;
 pub use plugin::Plugin;
 pub use proc_macros::{builder_args, rule, rule_tests, violation};

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -1,10 +1,10 @@
-use std::{collections::HashMap, ops, path::Path, sync::Arc};
+use std::{collections::HashMap, ops, sync::Arc};
 
 use tree_sitter_grep::{tree_sitter::QueryMatch, SupportedLanguage};
 
 use crate::{
     config::{PluginIndex, RuleConfiguration},
-    context::QueryMatchContext,
+    context::{FileRunContext, QueryMatchContext},
     tree_sitter::{Language, Node, Query},
     Config,
 };
@@ -29,7 +29,7 @@ pub trait Rule: Send + Sync {
 pub trait RuleInstance: Send + Sync {
     fn instantiate_per_file<'a>(
         self: Arc<Self>,
-        file_run_info: &FileRunInfo<'a>,
+        file_run_context: FileRunContext<'a>,
     ) -> Box<dyn RuleInstancePerFile<'a> + 'a>;
     fn rule(&self) -> Arc<dyn Rule>;
     fn listener_queries(&self) -> &[RuleListenerQuery];
@@ -131,10 +131,6 @@ pub trait RuleInstancePerFile<'a> {
         context: &mut QueryMatchContext<'a>,
     );
     fn rule_instance(&self) -> Arc<dyn RuleInstance>;
-}
-
-pub struct FileRunInfo<'a> {
-    pub path: &'a Path,
 }
 
 pub enum MatchBy {

--- a/src/rule_tester.rs
+++ b/src/rule_tester.rs
@@ -109,7 +109,8 @@ impl RuleTester {
             Some(RuleTestExpectedOutput::NoOutput) => {
                 assert!(
                     !violations.iter().any(|violation| violation.had_fixes),
-                    "Unexpected fixing violation was reported"
+                    "Unexpected fixing violation was reported for code {:#?}, got: {violations:#?}",
+                    invalid_test.code
                 );
             }
             _ => (),

--- a/src/tests/rules.rs
+++ b/src/tests/rules.rs
@@ -1128,3 +1128,44 @@ fn test_options_default() {
         },
     );
 }
+
+#[test]
+fn test_get_tokens_between() {
+    RuleTester::run(
+        rule! {
+            name => "uses-get-tokens-between",
+            listeners => [
+                r#"(
+                  (use_declaration) @c
+                )"# => |node, context| {
+                    if context.get_tokens_between(
+                        context.get_first_token(node, Option::<fn(Node) -> bool>::None),
+                        context.get_last_token(node, Option::<fn(Node) -> bool>::None),
+                        Option::<fn(Node) -> bool>::None
+                    ).count() == 3 {
+                        context.report(violation! {
+                            node => node,
+                            message => "whee",
+                        });
+                    }
+                }
+            ],
+            languages => [Rust],
+        },
+        rule_tests! {
+            valid => [
+                r#"
+                    use foo::bar::baz;
+                "#,
+            ],
+            invalid => [
+                {
+                    code => r#"
+                        use foo::bar;
+                    "#,
+                    errors => [{ message => "whee" }],
+                },
+            ]
+        },
+    );
+}

--- a/src/violation.rs
+++ b/src/violation.rs
@@ -42,7 +42,7 @@ impl<'a> Violation<'a> {
             message_or_message_id,
             range: range.unwrap_or_else(|| node.range()),
             kind: node.kind(),
-            path: query_match_context.path.to_owned(),
+            path: query_match_context.file_run_context.path.to_owned(),
             rule: query_match_context.rule.meta.clone(),
             plugin_index: query_match_context.rule.plugin_index,
             had_fixes,


### PR DESCRIPTION
In this PR:
- assume that a non-`Option<T>` rule options type should be `.unwrap_or_default()`'d unless you specify `options_type! => ...`

Based on `violation-range`