### PR TITLE
Set up tracing

### DIFF
--- a/.tree-sitter-lint/tree-sitter-lint-local/Cargo.toml
+++ b/.tree-sitter-lint/tree-sitter-lint-local/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 tree-sitter-lint = { path = "../.." }
 local_rules = { path = "../local_rules" }
 tree-sitter-lint-plugin-replace-foo-with = { path = "../.././tests/fixtures/tree-sitter-lint-plugin-replace-foo-with" }
+tracing = "0.1.37"
+tracing-subscriber = "0.3.17"
 
 [patch.crates-io]
 tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "c16b90d" }

--- a/.tree-sitter-lint/tree-sitter-lint-local/src/bin/tree-sitter-lint-local.rs
+++ b/.tree-sitter-lint/tree-sitter-lint-local/src/bin/tree-sitter-lint-local.rs
@@ -1,1 +1,3 @@
-fn main () { tree_sitter_lint_local :: run_and_output () ; }
+fn main() {
+    tree_sitter_lint_local::run_and_output();
+}

--- a/.tree-sitter-lint/tree-sitter-lint-local/src/lib.rs
+++ b/.tree-sitter-lint/tree-sitter-lint-local/src/lib.rs
@@ -13,6 +13,8 @@ use tree_sitter_lint::{
 };
 
 pub fn run_and_output() {
+    tracing_subscriber::fmt::init();
+
     tree_sitter_lint::run_and_output(
         args_to_config(Args::parse()),
         FromFileRunContextInstanceProviderFactoryLocal,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ text-diff = "0.4.0"
 tower-lsp = "0.19.0"
 tokio = { version = "1.29.1", features = ["full"] }
 better_any = "0.2.0"
+tracing = "0.1.37"
 
 [[bin]]
 name = "tree-sitter-lint"

--- a/src/aggregated_queries.rs
+++ b/src/aggregated_queries.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
+use tracing::instrument;
 use tree_sitter_grep::{tree_sitter::Query, SupportedLanguage};
 
 use crate::{
@@ -52,6 +53,7 @@ pub struct AggregatedQueries<
 impl<'a, TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProviderFactory>
     AggregatedQueries<'a, TFromFileRunContextInstanceProviderFactory>
 {
+    #[instrument(level = "debug", skip_all)]
     pub fn new(
         instantiated_rules: &'a [InstantiatedRule<TFromFileRunContextInstanceProviderFactory>],
     ) -> Self {

--- a/src/config/config_file.rs
+++ b/src/config/config_file.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use serde::Deserialize;
+use tracing::instrument;
 
 use super::{ErrorLevel, RuleConfiguration};
 use crate::rule::RuleOptions;
@@ -66,6 +67,7 @@ pub fn load_config_file() -> ParsedConfigFile {
 
 const CONFIG_FILENAME: &str = ".tree-sitter-lint.yml";
 
+#[instrument]
 pub fn find_config_file() -> PathBuf {
     find_filename_in_ancestor_directory(
         CONFIG_FILENAME,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,6 +7,7 @@ use std::{
 use clap::Parser;
 use derive_builder::Builder;
 use serde::Deserialize;
+use tracing::{instrument, trace_span};
 
 use crate::{
     rule::{InstantiatedRule, Rule, RuleOptions},
@@ -120,6 +121,8 @@ impl<TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProvi
         ),
     > {
         self.rules_by_plugin_prefixed_name.get_or_init(|| {
+            let _span = trace_span!("rules by plugin prefixed name init").entered();
+
             let mut rules_by_plugin_prefixed_name: HashMap<
                 String,
                 (
@@ -148,6 +151,7 @@ impl<TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProvi
     }
 
     #[allow(clippy::type_complexity)]
+    #[instrument(level = "trace", skip(self))]
     fn get_active_rules_and_associated_plugins_and_options(
         &self,
     ) -> Vec<(
@@ -209,6 +213,7 @@ impl<TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProvi
         }
     }
 
+    #[instrument(level = "debug", skip(self))]
     pub fn get_instantiated_rules(
         &self,
     ) -> Vec<InstantiatedRule<TFromFileRunContextInstanceProviderFactory>> {
@@ -219,12 +224,15 @@ impl<TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProvi
         }
         let active_rules_and_associated_plugins_and_options =
             self.filter_based_on_rule_argument(active_rules_and_associated_plugins_and_options);
-        active_rules_and_associated_plugins_and_options
-            .into_iter()
-            .map(|(rule, plugin_index, rule_config)| {
-                InstantiatedRule::new(rule.clone(), plugin_index, rule_config, self)
-            })
-            .collect()
+
+        trace_span!("instantiate rules").in_scope(|| {
+            active_rules_and_associated_plugins_and_options
+                .into_iter()
+                .map(|(rule, plugin_index, rule_config)| {
+                    InstantiatedRule::new(rule.clone(), plugin_index, rule_config, self)
+                })
+                .collect()
+        })
     }
 
     pub fn get_plugin_name(&self, plugin_index: PluginIndex) -> &str {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -17,7 +17,7 @@ use crate::{
 mod config_file;
 pub use config_file::{find_config_file, load_config_file, ParsedConfigFile};
 
-#[derive(Builder, Default, Parser)]
+#[derive(Builder, Debug, Default, Parser)]
 #[builder(default, setter(into, strip_option))]
 pub struct Args {
     #[arg(long)]

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use better_any::TidAble;
+use tracing::{debug, instrument};
 use tree_sitter_grep::{
     streaming_iterator::StreamingIterator, tree_sitter::Tree, RopeOrSlice, SupportedLanguage,
 };
@@ -144,7 +145,10 @@ impl<
         }
     }
 
+    #[instrument(level = "debug", skip(self))]
     pub fn report(&self, violation: Violation) {
+        debug!("reporting violation");
+
         let mut had_fixes = false;
         if self.file_run_context.config.fix {
             if let Some(fix) = violation.fix.as_ref() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,8 @@ pub use rule_tester::{
     RuleTestValid, RuleTester, RuleTests,
 };
 pub use slice::MutRopeOrSlice;
+use squalid::EverythingExt;
+use tracing::{debug, debug_span, info_span, instrument};
 use tree_sitter::Tree;
 use tree_sitter_grep::{
     get_matches, get_parser, streaming_iterator::StreamingIterator, tree_sitter::QueryMatch,
@@ -66,6 +68,7 @@ pub extern crate tokio;
 pub extern crate tree_sitter_grep;
 pub use tree_sitter_grep::{ropey, tree_sitter};
 
+#[instrument(skip_all)]
 pub fn run_and_output<
     TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProviderFactory,
 >(
@@ -76,6 +79,9 @@ pub fn run_and_output<
     if violations.is_empty() {
         process::exit(0);
     }
+
+    let _span = info_span!("printing violations").entered();
+
     for violation in violations {
         violation.print(&config);
     }
@@ -84,63 +90,7 @@ pub fn run_and_output<
 
 const MAX_FIX_ITERATIONS: usize = 10;
 
-fn run_per_file<
-    'a,
-    'b,
-    TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProviderFactory<Provider<'a> = TFromFileRunContextInstanceProvider>,
-    TFromFileRunContextInstanceProvider: FromFileRunContextInstanceProvider<'a, Parent = TFromFileRunContextInstanceProviderFactory>,
->(
-    file_run_context: FileRunContext<'a, 'b, TFromFileRunContextInstanceProviderFactory>,
-    mut on_found_violations: impl FnMut(Vec<ViolationWithContext>),
-    mut on_found_pending_fixes: impl FnMut(
-        Vec<PendingFix>,
-        &InstantiatedRule<TFromFileRunContextInstanceProviderFactory>,
-    ),
-) {
-    let mut instantiated_per_file_rules: HashMap<
-        RuleName,
-        Box<dyn RuleInstancePerFile<'a, TFromFileRunContextInstanceProviderFactory> + 'a>,
-    > = Default::default();
-    get_matches(
-        file_run_context.language.language(),
-        file_run_context.file_contents,
-        file_run_context.query,
-        Some(file_run_context.tree),
-    )
-    .for_each(|query_match| {
-        run_match(
-            file_run_context,
-            query_match,
-            file_run_context.aggregated_queries,
-            &mut instantiated_per_file_rules,
-            &mut on_found_violations,
-            |pending_fixes, instantiated_rule| {
-                on_found_pending_fixes(pending_fixes, instantiated_rule)
-            },
-        );
-    });
-
-    for (&instantiated_rule_index, &rule_listener_index) in &file_run_context
-        .aggregated_queries
-        .instantiated_rule_root_exit_rule_listener_indices
-    {
-        run_single_on_query_match_callback(
-            file_run_context,
-            &file_run_context.instantiated_rules[instantiated_rule_index],
-            &mut instantiated_per_file_rules,
-            rule_listener_index,
-            file_run_context.tree.root_node().into(),
-            &mut on_found_violations,
-            |pending_fixes| {
-                on_found_pending_fixes(
-                    pending_fixes,
-                    &file_run_context.instantiated_rules[instantiated_rule_index],
-                )
-            },
-        );
-    }
-}
-
+#[instrument(level = "debug", skip_all)]
 pub fn run<
     TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProviderFactory,
 >(
@@ -152,52 +102,73 @@ pub fn run<
     let tree_sitter_grep_args = get_tree_sitter_grep_args(&aggregated_queries, None);
     let all_violations: Mutex<HashMap<PathBuf, Vec<ViolationWithContext>>> = Default::default();
     let files_with_fixes: AllPendingFixes = Default::default();
-    tree_sitter_grep::run_with_single_per_file_callback(
-        tree_sitter_grep_args,
-        |dir_entry, language, file_contents, tree, query| {
-            let from_file_run_context_instance_provider =
-                from_file_run_context_instance_provider_factory.create();
-            run_per_file(
-                FileRunContext::new(
-                    dir_entry.path(),
-                    file_contents,
-                    tree,
-                    config,
-                    language,
-                    &aggregated_queries,
-                    query,
-                    &instantiated_rules,
-                    &from_file_run_context_instance_provider,
-                ),
-                |violations| {
-                    all_violations
-                        .lock()
-                        .unwrap()
-                        .entry(dir_entry.path().to_owned())
-                        .or_default()
-                        .extend(violations)
-                },
-                |fixes, instantiated_rule| {
-                    files_with_fixes.append(
+
+    info_span!("first pass for all files").in_scope(|| {
+        tree_sitter_grep::run_with_single_per_file_callback(
+            tree_sitter_grep_args,
+            |dir_entry, language, file_contents, tree, query| {
+                let from_file_run_context_instance_provider =
+                    from_file_run_context_instance_provider_factory.create();
+                run_per_file(
+                    FileRunContext::new(
                         dir_entry.path(),
                         file_contents,
-                        &instantiated_rule.meta.name,
-                        fixes,
+                        tree,
+                        config,
                         language,
-                    )
-                },
-            );
-        },
-    )
-    .unwrap();
+                        &aggregated_queries,
+                        query,
+                        &instantiated_rules,
+                        &from_file_run_context_instance_provider,
+                    ),
+                    |violations| {
+                        all_violations
+                            .lock()
+                            .unwrap()
+                            .entry(dir_entry.path().to_owned())
+                            .or_default()
+                            .extend(violations)
+                    },
+                    |fixes, instantiated_rule| {
+                        files_with_fixes.append(
+                            dir_entry.path(),
+                            file_contents,
+                            &instantiated_rule.meta.name,
+                            fixes,
+                            language,
+                        )
+                    },
+                );
+            },
+        )
+        .unwrap();
+    });
+
     let mut all_violations = all_violations.into_inner().unwrap();
     if !config.fix {
-        return all_violations.into_values().flatten().collect();
+        let violations = all_violations.into_values().flatten().collect::<Vec<_>>();
+
+        debug!(
+            num_violations = violations.len(),
+            "non-fixing mode, returning after initial pass"
+        );
+
+        return violations;
     }
     let files_with_fixes = files_with_fixes.into_inner().unwrap();
     if files_with_fixes.is_empty() {
-        return all_violations.into_values().flatten().collect();
+        let violations = all_violations.into_values().flatten().collect::<Vec<_>>();
+
+        debug!(
+            num_violations = violations.len(),
+            "fixing mode, returning after initial pass"
+        );
+
+        return violations;
     }
+
+    let span = info_span!("running fixing loop for all files").entered();
+
     let aggregated_results_from_files_with_fixes: HashMap<
         PathBuf,
         (Vec<u8>, Vec<ViolationWithContext>),
@@ -228,6 +199,9 @@ pub fn run<
             },
         )
         .collect();
+
+    span.exit();
+
     write_files(
         aggregated_results_from_files_with_fixes
             .iter()
@@ -239,6 +213,71 @@ pub fn run<
     all_violations.into_values().flatten().collect()
 }
 
+#[instrument(skip_all, fields(path = ?file_run_context.path, language = ?file_run_context.language))]
+fn run_per_file<
+    'a,
+    'b,
+    TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProviderFactory,
+>(
+    file_run_context: FileRunContext<'a, 'b, TFromFileRunContextInstanceProviderFactory>,
+    mut on_found_violations: impl FnMut(Vec<ViolationWithContext>),
+    mut on_found_pending_fixes: impl FnMut(
+        Vec<PendingFix>,
+        &InstantiatedRule<TFromFileRunContextInstanceProviderFactory>,
+    ),
+) {
+    let mut instantiated_per_file_rules: HashMap<
+        RuleName,
+        Box<dyn RuleInstancePerFile<'a, TFromFileRunContextInstanceProviderFactory> + 'a>,
+    > = Default::default();
+
+    let span = debug_span!("loop through query matches").entered();
+
+    get_matches(
+        file_run_context.language.language(),
+        file_run_context.file_contents,
+        file_run_context.query,
+        Some(file_run_context.tree),
+    )
+    .for_each(|query_match| {
+        run_match(
+            file_run_context,
+            query_match,
+            file_run_context.aggregated_queries,
+            &mut instantiated_per_file_rules,
+            &mut on_found_violations,
+            |pending_fixes, instantiated_rule| {
+                on_found_pending_fixes(pending_fixes, instantiated_rule)
+            },
+        );
+    });
+
+    span.exit();
+
+    let _span = debug_span!("run root exit listeners").entered();
+
+    for (&instantiated_rule_index, &rule_listener_index) in &file_run_context
+        .aggregated_queries
+        .instantiated_rule_root_exit_rule_listener_indices
+    {
+        run_single_on_query_match_callback(
+            file_run_context,
+            &file_run_context.instantiated_rules[instantiated_rule_index],
+            &mut instantiated_per_file_rules,
+            rule_listener_index,
+            file_run_context.tree.root_node().into(),
+            &mut on_found_violations,
+            |pending_fixes| {
+                on_found_pending_fixes(
+                    pending_fixes,
+                    &file_run_context.instantiated_rules[instantiated_rule_index],
+                )
+            },
+        );
+    }
+}
+
+#[instrument(level = "debug", skip_all, fields(?query_match))]
 fn run_match<
     'a,
     'b,
@@ -299,6 +338,7 @@ fn run_match<
     }
 }
 
+#[instrument(level = "debug", skip_all)]
 fn run_single_on_query_match_callback<
     'a,
     'b,
@@ -320,19 +360,36 @@ fn run_single_on_query_match_callback<
     instantiated_per_file_rules
         .entry(instantiated_rule.meta.name.clone())
         .or_insert_with(|| {
+            let _span = debug_span!(
+                "instantiate rule per file",
+                name = instantiated_rule.meta.name
+            )
+            .entered();
+
             instantiated_rule
                 .rule_instance
                 .clone()
                 .instantiate_per_file(file_run_context)
         })
-        .on_query_match(
-            rule_listener_index,
-            node_or_captures,
-            &mut query_match_context,
-        );
+        .thrush(|rule_instance_per_file| {
+            let _span = debug_span!(
+                "run rule listener callback",
+                name = instantiated_rule.meta.name,
+                rule_listener_index
+            )
+            .entered();
+
+            rule_instance_per_file.on_query_match(
+                rule_listener_index,
+                node_or_captures,
+                &mut query_match_context,
+            );
+        });
+
     if let Some(violations) = query_match_context.violations.take() {
         on_found_violations(violations);
     }
+
     if let Some(fixes) = query_match_context.into_pending_fixes() {
         assert!(file_run_context.config.fix);
         on_found_pending_fixes(fixes);
@@ -340,6 +397,7 @@ fn run_single_on_query_match_callback<
 }
 
 #[allow(clippy::too_many_arguments)]
+#[instrument(level = "debug", skip_all, fields(?path))]
 fn run_fixing_loop<
     'a,
     TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProviderFactory,
@@ -356,6 +414,8 @@ fn run_fixing_loop<
 ) {
     let mut file_contents = file_contents.into();
     for _ in 0..MAX_FIX_ITERATIONS {
+        let _span = debug_span!("single fixing loop pass").entered();
+
         apply_fixes(&mut file_contents, pending_fixes);
         pending_fixes = Default::default();
         if config.report_fixed_violations {
@@ -367,10 +427,16 @@ fn run_fixing_loop<
         } else {
             violations.clear();
         }
+
+        let parse_span = debug_span!("tree-sitter parse").entered();
+
         // TODO: this looks like tree could be passed in and incrementally re-parsed?
         let tree = RopeOrSlice::<'_>::from(&file_contents)
             .parse(&mut get_parser(language.language()), None)
             .unwrap();
+
+        parse_span.exit();
+
         let from_file_run_context_instance_provider =
             from_file_run_context_instance_provider_factory.create();
         run_per_file(
@@ -400,6 +466,7 @@ fn run_fixing_loop<
             },
         );
         if pending_fixes.is_empty() {
+            debug!("no fixes reported, exiting fixing loop");
             break;
         }
     }
@@ -410,6 +477,7 @@ fn run_fixing_loop<
 //     pub from_file_run_context_instance_provider: Box<dyn FromFileRunContextInstanceProvider>,
 // }
 
+#[instrument(skip_all, fields(path = ?path.as_ref(), ?language))]
 pub fn run_for_slice<
     'a,
     TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProviderFactory,
@@ -431,6 +499,8 @@ pub fn run_for_slice<
     let violations: Mutex<Vec<ViolationWithContext>> = Default::default();
     let tree: Cow<'_, Tree> = tree.map_or_else(
         || {
+            let _span = debug_span!("tree-sitter parse").entered();
+
             Cow::Owned(
                 file_contents
                     .parse(&mut get_parser(language.language()), None)
@@ -471,6 +541,7 @@ pub fn run_for_slice<
     // }
 }
 
+#[instrument(skip_all, fields(path = ?path.as_ref(), ?language))]
 pub fn run_fixing_for_slice<
     'a,
     TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProviderFactory,
@@ -491,6 +562,8 @@ pub fn run_fixing_for_slice<
     let aggregated_queries = AggregatedQueries::new(&instantiated_rules);
     let tree: Cow<'_, Tree> = tree.map_or_else(
         || {
+            let _span = debug_span!("tree-sitter parse").entered();
+
             Cow::Owned(
                 RopeOrSlice::<'_>::from(&file_contents)
                     .parse(&mut get_parser(language.language()), None)
@@ -568,14 +641,18 @@ fn get_tree_sitter_grep_args(
         .unwrap()
 }
 
+#[instrument(level = "debug", skip_all)]
 fn write_files<'a>(files_to_write: impl Iterator<Item = (&'a Path, &'a [u8])>) {
     for (path, file_contents) in files_to_write {
+        let _span = debug_span!("write file", ?path).entered();
+
         fs::write(path, file_contents).unwrap();
     }
 }
 
 type RuleName = String;
 
+#[instrument(level = "debug", skip_all)]
 fn apply_fixes(
     file_contents: &mut MutRopeOrSlice,
     pending_fixes: HashMap<RuleName, Vec<PendingFix>>,

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -162,12 +162,13 @@ impl RuleListenerQuery {
         let query = Query::new(language, &self.query).unwrap();
         let resolved_match_by = match &self.match_by {
             MatchBy::PerCapture { capture_name } => ResolvedMatchBy::PerCapture {
-                capture_index: match capture_name.as_ref() {
+                capture_name: match capture_name.as_ref() {
                     None => match query.capture_names().len() {
                         0 => panic!("Expected capture"),
-                        _ => 0,
+                        _ => query.capture_names()[0].clone(),
                     },
-                    Some(capture_name) => query.capture_index_for_name(capture_name).unwrap(),
+                    // Some(capture_name) => query.capture_index_for_name(capture_name).unwrap(),
+                    Some(capture_name) => capture_name.clone(),
                 },
             },
             MatchBy::PerMatch => ResolvedMatchBy::PerMatch,
@@ -181,7 +182,7 @@ impl RuleListenerQuery {
 }
 
 pub enum ResolvedMatchBy {
-    PerCapture { capture_index: u32 },
+    PerCapture { capture_name: String },
     PerMatch,
 }
 
@@ -189,17 +190,6 @@ pub struct ResolvedRuleListenerQuery {
     pub query: Query,
     pub query_text: String,
     pub match_by: ResolvedMatchBy,
-}
-
-impl ResolvedRuleListenerQuery {
-    pub fn capture_name(&self) -> &str {
-        match &self.match_by {
-            ResolvedMatchBy::PerCapture { capture_index } => {
-                &self.query.capture_names()[*capture_index as usize]
-            }
-            _ => panic!("Called capture_name() for PerMatch"),
-        }
-    }
 }
 
 pub type RuleOptions = serde_json::Value;

--- a/src/violation.rs
+++ b/src/violation.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap, path::PathBuf, rc::Rc};
+use std::{borrow::Cow, collections::HashMap, fmt, path::PathBuf, rc::Rc};
 
 use derive_builder::Builder;
 use tree_sitter_grep::tree_sitter::Range;
@@ -23,6 +23,18 @@ pub struct Violation<'a> {
     pub data: Option<ViolationData>,
     #[builder(default)]
     pub range: Option<Range>,
+}
+
+impl<'a> fmt::Debug for Violation<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Violation")
+            .field("message_or_message_id", &self.message_or_message_id)
+            .field("node", &self.node)
+            .field("has_fix", &self.fix.is_some())
+            .field("data", &self.data)
+            .field("range", &self.range)
+            .finish()
+    }
 }
 
 impl<'a> Violation<'a> {

--- a/tests/fixtures/tree-sitter-lint-plugin-replace-foo-with/src/lib.rs
+++ b/tests/fixtures/tree-sitter-lint-plugin-replace-foo-with/src/lib.rs
@@ -18,7 +18,6 @@ impl<'a> FromFileRunContext<'a> for Foo<'a> {
     fn from_file_run_context(
         file_run_context: FileRunContext<'a, '_, impl FromFileRunContextInstanceProviderFactory>,
     ) -> Self {
-        println!("instantiating Foo for {:#?}", file_run_context.path);
         Self {
             text: match &file_run_context.file_contents {
                 RopeOrSlice::Slice(file_contents) => {


### PR DESCRIPTION
In this PR:
- set up `tracing` for some top-level stuff
- fix a bug with capture index

To test:
If you manually rebuild the custom local binary (its code-generation isn't in sync) and then from the repo root do eg `RUST_LOG=trace cargo run` you should see some tracing events with enclosing span info printed out

Based on `from-file-run-context`