### PR TITLE
Exit node listeners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+trace-*.json

--- a/.tree-sitter-lint/local_rules/Cargo.toml
+++ b/.tree-sitter-lint/local_rules/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tracing = "0.1.37"
 tree-sitter-lint = { path = "../.." }
 
 [patch.crates-io]

--- a/.tree-sitter-lint/local_rules/src/lib.rs
+++ b/.tree-sitter-lint/local_rules/src/lib.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use tree_sitter_lint::{FromFileRunContextInstanceProviderFactory, Rule};
+use tree_sitter_lint::Rule;
 
 mod rules;
 
@@ -9,7 +9,7 @@ use rules::{
     require_blazing_keyword_rule,
 };
 
-pub fn get_rules<T: FromFileRunContextInstanceProviderFactory>() -> Vec<Arc<dyn Rule<T>>> {
+pub fn get_rules() -> Vec<Arc<dyn Rule>> {
     vec![
         no_default_default_rule(),
         no_lazy_static_rule(),

--- a/.tree-sitter-lint/local_rules/src/rules/no_default_default.rs
+++ b/.tree-sitter-lint/local_rules/src/rules/no_default_default.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-use tree_sitter_lint::{rule, violation, FromFileRunContextInstanceProviderFactory, Rule};
+use tree_sitter_lint::{rule, violation, Rule};
 
-pub fn no_default_default_rule<T: FromFileRunContextInstanceProviderFactory>() -> Arc<dyn Rule<T>> {
+pub fn no_default_default_rule() -> Arc<dyn Rule> {
     rule! {
         name => "no-default-default",
         fixable => true,

--- a/.tree-sitter-lint/local_rules/src/rules/no_lazy_static.rs
+++ b/.tree-sitter-lint/local_rules/src/rules/no_lazy_static.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-use tree_sitter_lint::{rule, violation, FromFileRunContextInstanceProviderFactory, Rule};
+use tree_sitter_lint::{rule, violation, Rule};
 
-pub fn no_lazy_static_rule<T: FromFileRunContextInstanceProviderFactory>() -> Arc<dyn Rule<T>> {
+pub fn no_lazy_static_rule() -> Arc<dyn Rule> {
     rule! {
         name => "no-lazy-static",
         listeners => [

--- a/.tree-sitter-lint/local_rules/src/rules/prefer_impl_param.rs
+++ b/.tree-sitter-lint/local_rules/src/rules/prefer_impl_param.rs
@@ -1,9 +1,7 @@
 use std::sync::Arc;
 
 use tracing::{instrument, trace_span};
-use tree_sitter_lint::{
-    rule, tree_sitter::Node, violation, FromFileRunContextInstanceProviderFactory, Rule,
-};
+use tree_sitter_lint::{rule, tree_sitter::Node, violation, Rule};
 
 #[macro_export]
 macro_rules! assert_node_kind {
@@ -90,7 +88,7 @@ macro_rules! query {
     }};
 }
 
-pub fn prefer_impl_param_rule<T: FromFileRunContextInstanceProviderFactory>() -> Arc<dyn Rule<T>> {
+pub fn prefer_impl_param_rule() -> Arc<dyn Rule> {
     rule! {
         name => "prefer-impl-param",
         listeners => [

--- a/.tree-sitter-lint/local_rules/src/rules/prefer_impl_param.rs
+++ b/.tree-sitter-lint/local_rules/src/rules/prefer_impl_param.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use tracing::{instrument, trace_span};
 use tree_sitter_lint::{
     rule, tree_sitter::Node, violation, FromFileRunContextInstanceProviderFactory, Rule,
 };
@@ -12,6 +13,7 @@ macro_rules! assert_node_kind {
     }};
 }
 
+#[instrument(level = "trace")]
 fn get_constrained_type_parameter_name(node: Node) -> Node {
     assert_node_kind!(node, "constrained_type_parameter");
     let name_node = node.child_by_field_name("left").unwrap();
@@ -101,16 +103,29 @@ pub fn prefer_impl_param_rule<T: FromFileRunContextInstanceProviderFactory>() ->
             )"# => |node, context| {
                 let type_parameter_name =
                     context.get_node_text(get_constrained_type_parameter_name(node));
+
+                let span = trace_span!("get type identifier query").entered();
+
                 let type_identifier_query =
                     query!(
                         r#"(type_identifier) @c"#,
                         context.language().language(),
                     );
+
+                span.exit();
+
+                let span = trace_span!("look for single usage in parameters").entered();
+
                 return_if_none!(context.maybe_get_single_captured_node_for_filtered_query(
                     type_identifier_query,
                     |node| context.get_node_text(node) == type_parameter_name,
                     get_parameters_node_of_enclosing_function(node)
                 ));
+
+                span.exit();
+
+                let span = trace_span!("look for usage in return type").entered();
+
                 if let Some(return_type_node) =
                     maybe_get_return_type_node_of_enclosing_function(node)
                 {
@@ -127,16 +142,28 @@ pub fn prefer_impl_param_rule<T: FromFileRunContextInstanceProviderFactory>() ->
                         return;
                     }
                 }
+
+                span.exit();
+
                 let type_parameters_node =
                     assert_node_kind!(node.parent().unwrap(), "type_parameters");
+
+                let span = trace_span!("looking for other usages in type parameters").entered();
+
                 let only_found_the_defining_usage_in_the_type_parameters = context.maybe_get_single_captured_node_for_filtered_query(
                     type_identifier_query,
                     |node| context.get_node_text(node) == type_parameter_name,
                     type_parameters_node
                 ).is_some();
+
+                span.exit();
+
                 if !only_found_the_defining_usage_in_the_type_parameters {
                     return;
                 }
+
+                let span = trace_span!("looking in where clause").entered();
+
                 if let Some(where_clause_node) =
                     maybe_get_where_clause_node_of_enclosing_function(node)
                 {
@@ -148,6 +175,9 @@ pub fn prefer_impl_param_rule<T: FromFileRunContextInstanceProviderFactory>() ->
                         return;
                     }
                 }
+
+                span.exit();
+
                 context.report(
                     violation! {
                         message => r#"Prefer using 'param: impl Trait'"#,

--- a/.tree-sitter-lint/local_rules/src/rules/require_blazing_keyword.rs
+++ b/.tree-sitter-lint/local_rules/src/rules/require_blazing_keyword.rs
@@ -1,9 +1,8 @@
 use std::sync::Arc;
 
-use tree_sitter_lint::{rule, violation, FromFileRunContextInstanceProviderFactory, Rule};
+use tree_sitter_lint::{rule, violation, Rule};
 
-pub fn require_blazing_keyword_rule<T: FromFileRunContextInstanceProviderFactory>(
-) -> Arc<dyn Rule<T>> {
+pub fn require_blazing_keyword_rule() -> Arc<dyn Rule> {
     rule! {
         name => "require-blazing-keyword",
         languages => [Toml],

--- a/.tree-sitter-lint/tree-sitter-lint-local/Cargo.toml
+++ b/.tree-sitter-lint/tree-sitter-lint-local/Cargo.toml
@@ -9,6 +9,7 @@ local_rules = { path = "../local_rules" }
 tree-sitter-lint-plugin-replace-foo-with = { path = "../.././tests/fixtures/tree-sitter-lint-plugin-replace-foo-with" }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
+tracing-chrome = "0.7.1"
 
 [patch.crates-io]
 tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "c16b90d" }

--- a/.tree-sitter-lint/tree-sitter-lint-local/src/bin/tree-sitter-lint-local.rs
+++ b/.tree-sitter-lint/tree-sitter-lint-local/src/bin/tree-sitter-lint-local.rs
@@ -1,3 +1,11 @@
+use tracing_chrome::ChromeLayerBuilder;
+use tracing_subscriber::prelude::*;
+
 fn main() {
+    // tracing_subscriber::fmt::init();
+
+    let (chrome_layer, _guard) = ChromeLayerBuilder::new().include_args(true).build();
+    tracing_subscriber::registry().with(chrome_layer).init();
+
     tree_sitter_lint_local::run_and_output();
 }

--- a/.tree-sitter-lint/tree-sitter-lint-local/src/lib.rs
+++ b/.tree-sitter-lint/tree-sitter-lint-local/src/lib.rs
@@ -13,8 +13,6 @@ use tree_sitter_lint::{
 };
 
 pub fn run_and_output() {
-    tracing_subscriber::fmt::init();
-
     tree_sitter_lint::run_and_output(
         args_to_config(Args::parse()),
         FromFileRunContextInstanceProviderFactoryLocal,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ tower-lsp = "0.19.0"
 tokio = { version = "1.29.1", features = ["full"] }
 better_any = "0.2.0"
 tracing = "0.1.37"
+once_cell = "1.18.0"
 
 [[bin]]
 name = "tree-sitter-lint"

--- a/proc_macros/src/rule.rs
+++ b/proc_macros/src/rule.rs
@@ -513,7 +513,7 @@ fn get_rule_rule_impl(
         None => quote!(None),
     };
     quote! {
-        impl<TFr: #crate_name::FromFileRunContextInstanceProviderFactory> #crate_name::Rule<TFr> for #rule_struct_name {
+        impl #crate_name::Rule for #rule_struct_name {
             fn meta(&self) -> #crate_name::RuleMeta {
                 #crate_name::RuleMeta {
                     name: #name.into(),
@@ -525,9 +525,9 @@ fn get_rule_rule_impl(
 
             fn instantiate(
                 self: std::sync::Arc<Self>,
-                _config: &#crate_name::Config<TFr>,
+                _config: &#crate_name::Config,
                 rule_configuration: &#crate_name::RuleConfiguration,
-            ) -> std::sync::Arc<dyn #crate_name::RuleInstance<TFr>> {
+            ) -> std::sync::Arc<dyn #crate_name::RuleInstance> {
                 let options = rule_configuration.options.as_ref();
                 #maybe_deserialize_options
                 std::sync::Arc::new(#rule_instance_struct_name {
@@ -578,11 +578,11 @@ fn get_rule_instance_rule_instance_impl(
             None => quote!(Default::default()),
         });
     quote! {
-        impl<TFr: #crate_name::FromFileRunContextInstanceProviderFactory> #crate_name::RuleInstance<TFr> for #rule_instance_struct_name {
+        impl #crate_name::RuleInstance for #rule_instance_struct_name {
             fn instantiate_per_file<'a>(
                 self: std::sync::Arc<Self>,
-                _file_run_context: #crate_name::FileRunContext<'a, '_, TFr>,
-            ) -> Box<dyn #crate_name::RuleInstancePerFile<'a, TFr> + 'a> {
+                _file_run_context: #crate_name::FileRunContext<'a, '_>,
+            ) -> Box<dyn #crate_name::RuleInstancePerFile<'a> + 'a> {
                 Box::new(#rule_instance_per_file_struct_name {
                     rule_instance: self,
                     _phantom_data: std::marker::PhantomData,
@@ -590,7 +590,7 @@ fn get_rule_instance_rule_instance_impl(
                 })
             }
 
-            fn rule(&self) -> std::sync::Arc<dyn #crate_name::Rule<TFr>> {
+            fn rule(&self) -> std::sync::Arc<dyn #crate_name::Rule> {
                 self.rule.clone()
             }
 
@@ -762,8 +762,8 @@ fn get_rule_instance_per_file_rule_instance_per_file_impl(
         }
     });
     quote! {
-        impl<'a, TFr: #crate_name::FromFileRunContextInstanceProviderFactory> #crate_name::RuleInstancePerFile<'a, TFr> for #rule_instance_per_file_struct_name<'a> {
-            fn on_query_match<'b>(&mut self, listener_index: usize, node_or_captures: #crate_name::NodeOrCaptures<'a, 'b>, context: &mut #crate_name::QueryMatchContext<'a, '_, TFr>) {
+        impl<'a> #crate_name::RuleInstancePerFile<'a> for #rule_instance_per_file_struct_name<'a> {
+            fn on_query_match<'b>(&mut self, listener_index: usize, node_or_captures: #crate_name::NodeOrCaptures<'a, 'b>, context: &mut #crate_name::QueryMatchContext<'a, '_>) {
                 match listener_index {
                     #(#listener_indices => {
                         #listener_callbacks
@@ -772,7 +772,7 @@ fn get_rule_instance_per_file_rule_instance_per_file_impl(
                 }
             }
 
-            fn rule_instance(&self) -> std::sync::Arc<dyn #crate_name::RuleInstance<TFr>> {
+            fn rule_instance(&self) -> std::sync::Arc<dyn #crate_name::RuleInstance> {
                 self.rule_instance.clone()
             }
         }

--- a/proc_macros/src/rule.rs
+++ b/proc_macros/src/rule.rs
@@ -182,7 +182,6 @@ struct Rule {
     are_options_required: bool,
     languages: Vec<Ident>,
     messages: Option<HashMap<Expr, Expr>>,
-    isolated_to_query_subtrees: Option<Expr>,
 }
 
 impl Rule {
@@ -220,7 +219,6 @@ impl Parse for Rule {
         let mut languages: Option<Vec<Ident>> = Default::default();
         let mut messages: Option<HashMap<Expr, Expr>> = Default::default();
         let mut are_options_required: bool = Default::default();
-        let mut isolated_to_query_subtrees: Option<Expr> = Default::default();
         while !input.is_empty() {
             let key: Ident = input.parse()?;
             if key.to_string() == "options_type" {
@@ -286,13 +284,6 @@ impl Parse for Rule {
                         }
                     }
                 }
-                "isolated_to_query_subtrees" => {
-                    assert!(
-                        isolated_to_query_subtrees.is_none(),
-                        "Already saw 'isolated_to_query_subtrees' key"
-                    );
-                    isolated_to_query_subtrees = Some(input.parse()?);
-                }
                 _ => panic!("didn't expect key '{}'", key),
             }
             if !input.is_empty() {
@@ -308,7 +299,6 @@ impl Parse for Rule {
             languages: languages.expect("Expected 'languages'"),
             messages,
             are_options_required,
-            isolated_to_query_subtrees,
         })
     }
 }
@@ -522,10 +512,6 @@ fn get_rule_rule_impl(
         }
         None => quote!(None),
     };
-    let isolated_to_query_subtrees = match rule.isolated_to_query_subtrees.as_ref() {
-        Some(isolated_to_query_subtrees) => quote!(#isolated_to_query_subtrees),
-        None => quote!(false),
-    };
     quote! {
         impl<TFr: #crate_name::FromFileRunContextInstanceProviderFactory> #crate_name::Rule<TFr> for #rule_struct_name {
             fn meta(&self) -> #crate_name::RuleMeta {
@@ -534,7 +520,6 @@ fn get_rule_rule_impl(
                     fixable: #fixable,
                     languages: vec![#(#crate_name::tree_sitter_grep::SupportedLanguage::#languages),*],
                     messages: #messages,
-                    isolated_to_query_subtrees: #isolated_to_query_subtrees,
                 }
             }
 

--- a/proc_macros/src/rule.rs
+++ b/proc_macros/src/rule.rs
@@ -182,6 +182,7 @@ struct Rule {
     are_options_required: bool,
     languages: Vec<Ident>,
     messages: Option<HashMap<Expr, Expr>>,
+    isolated_to_query_subtrees: Option<Expr>,
 }
 
 impl Rule {
@@ -219,6 +220,7 @@ impl Parse for Rule {
         let mut languages: Option<Vec<Ident>> = Default::default();
         let mut messages: Option<HashMap<Expr, Expr>> = Default::default();
         let mut are_options_required: bool = Default::default();
+        let mut isolated_to_query_subtrees: Option<Expr> = Default::default();
         while !input.is_empty() {
             let key: Ident = input.parse()?;
             if key.to_string() == "options_type" {
@@ -284,6 +286,13 @@ impl Parse for Rule {
                         }
                     }
                 }
+                "isolated_to_query_subtrees" => {
+                    assert!(
+                        isolated_to_query_subtrees.is_none(),
+                        "Already saw 'isolated_to_query_subtrees' key"
+                    );
+                    isolated_to_query_subtrees = Some(input.parse()?);
+                }
                 _ => panic!("didn't expect key '{}'", key),
             }
             if !input.is_empty() {
@@ -299,6 +308,7 @@ impl Parse for Rule {
             languages: languages.expect("Expected 'languages'"),
             messages,
             are_options_required,
+            isolated_to_query_subtrees,
         })
     }
 }
@@ -512,6 +522,10 @@ fn get_rule_rule_impl(
         }
         None => quote!(None),
     };
+    let isolated_to_query_subtrees = match rule.isolated_to_query_subtrees.as_ref() {
+        Some(isolated_to_query_subtrees) => quote!(#isolated_to_query_subtrees),
+        None => quote!(false),
+    };
     quote! {
         impl<TFr: #crate_name::FromFileRunContextInstanceProviderFactory> #crate_name::Rule<TFr> for #rule_struct_name {
             fn meta(&self) -> #crate_name::RuleMeta {
@@ -520,6 +534,7 @@ fn get_rule_rule_impl(
                     fixable: #fixable,
                     languages: vec![#(#crate_name::tree_sitter_grep::SupportedLanguage::#languages),*],
                     messages: #messages,
+                    isolated_to_query_subtrees: #isolated_to_query_subtrees,
                 }
             }
 

--- a/src/aggregated_queries.rs
+++ b/src/aggregated_queries.rs
@@ -37,7 +37,16 @@ impl AggregatedQueriesPerLanguageBuilder {
             kind_exit_rule_listener_indices,
         } = self;
 
-        query_text.push_str("\n(_) @c");
+        if !kind_exit_rule_listener_indices.is_empty() {
+            query_text.push_str(&format!(
+                "\n[{}] @c",
+                kind_exit_rule_listener_indices
+                    .keys()
+                    .map(|kind| format!("({kind})"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            ));
+        }
 
         let span = trace_span!("parse aggregated query").entered();
 
@@ -45,7 +54,15 @@ impl AggregatedQueriesPerLanguageBuilder {
 
         span.exit();
 
-        assert!(query.pattern_count() == pattern_index_lookup.len() + 1);
+        assert!(
+            query.pattern_count()
+                == pattern_index_lookup.len()
+                    + if kind_exit_rule_listener_indices.is_empty() {
+                        0
+                    } else {
+                        1
+                    }
+        );
         AggregatedQueriesPerLanguage {
             pattern_index_lookup: {
                 let span = trace_span!("resolve capture indexes").entered();

--- a/src/aggregated_queries.rs
+++ b/src/aggregated_queries.rs
@@ -5,7 +5,7 @@ use tree_sitter_grep::{tree_sitter::Query, SupportedLanguage};
 
 use crate::{
     rule::{InstantiatedRule, ResolvedMatchBy},
-    FromFileRunContextInstanceProviderFactory, ROOT_EXIT,
+    ROOT_EXIT,
 };
 
 type RuleIndex = usize;
@@ -71,22 +71,15 @@ impl AggregatedQueriesPerLanguageBuilder {
     }
 }
 
-pub struct AggregatedQueries<
-    'a,
-    TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProviderFactory,
-> {
-    pub instantiated_rules: &'a [InstantiatedRule<TFromFileRunContextInstanceProviderFactory>],
+pub struct AggregatedQueries<'a> {
+    pub instantiated_rules: &'a [InstantiatedRule],
     pub per_language: HashMap<SupportedLanguage, AggregatedQueriesPerLanguage>,
     pub instantiated_rule_root_exit_rule_listener_indices: HashMap<RuleIndex, RuleListenerIndex>,
 }
 
-impl<'a, TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProviderFactory>
-    AggregatedQueries<'a, TFromFileRunContextInstanceProviderFactory>
-{
+impl<'a> AggregatedQueries<'a> {
     #[instrument(level = "debug", skip_all)]
-    pub fn new(
-        instantiated_rules: &'a [InstantiatedRule<TFromFileRunContextInstanceProviderFactory>],
-    ) -> Self {
+    pub fn new(instantiated_rules: &'a [InstantiatedRule]) -> Self {
         let mut per_language: HashMap<SupportedLanguage, AggregatedQueriesPerLanguageBuilder> =
             Default::default();
         let mut instantiated_rule_root_exit_rule_listener_indices: HashMap<
@@ -170,7 +163,7 @@ impl<'a, TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceP
         language: SupportedLanguage,
         pattern_index: usize,
     ) -> (
-        &'a InstantiatedRule<TFromFileRunContextInstanceProviderFactory>,
+        &'a InstantiatedRule,
         RuleListenerIndex,
         CaptureIndexIfPerCapture,
     ) {

--- a/src/aggregated_queries.rs
+++ b/src/aggregated_queries.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
 use tracing::{instrument, trace, trace_span};
 use tree_sitter_grep::{tree_sitter::Query, SupportedLanguage};
@@ -81,7 +78,6 @@ pub struct AggregatedQueries<
     pub instantiated_rules: &'a [InstantiatedRule<TFromFileRunContextInstanceProviderFactory>],
     pub per_language: HashMap<SupportedLanguage, AggregatedQueriesPerLanguage>,
     pub instantiated_rule_root_exit_rule_listener_indices: HashMap<RuleIndex, RuleListenerIndex>,
-    pub isolated_to_query_subtrees_instantiated_rules: HashSet<RuleIndex>,
 }
 
 impl<'a, TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProviderFactory>
@@ -97,16 +93,10 @@ impl<'a, TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceP
             RuleIndex,
             RuleListenerIndex,
         > = Default::default();
-        let mut isolated_to_query_subtrees_instantiated_rules: HashSet<RuleIndex> =
-            Default::default();
 
         let span = trace_span!("resolve individual rule listener queries").entered();
 
         for (rule_index, instantiated_rule) in instantiated_rules.into_iter().enumerate() {
-            if instantiated_rule.meta.isolated_to_query_subtrees {
-                isolated_to_query_subtrees_instantiated_rules.insert(rule_index);
-            }
-
             for &language in &instantiated_rule.meta.languages {
                 let per_language_builder = per_language.entry(language).or_default();
                 for (rule_listener_index, rule_listener_query) in instantiated_rule
@@ -172,7 +162,6 @@ impl<'a, TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceP
                 per_language
             },
             instantiated_rule_root_exit_rule_listener_indices,
-            isolated_to_query_subtrees_instantiated_rules,
         }
     }
 
@@ -182,7 +171,6 @@ impl<'a, TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceP
         pattern_index: usize,
     ) -> (
         &'a InstantiatedRule<TFromFileRunContextInstanceProviderFactory>,
-        RuleIndex,
         RuleListenerIndex,
         CaptureIndexIfPerCapture,
     ) {
@@ -194,7 +182,6 @@ impl<'a, TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceP
         let instantiated_rule = &self.instantiated_rules[rule_index];
         (
             instantiated_rule,
-            rule_index,
             rule_listener_index,
             capture_index_if_per_capture,
         )

--- a/src/context/fix.rs
+++ b/src/context/fix.rs
@@ -1,7 +1,5 @@
-use std::ops;
-
 use squalid::{IsEmpty, OptionExt};
-use tree_sitter_grep::tree_sitter::Node;
+use tree_sitter_grep::tree_sitter::{Node, Range};
 
 #[derive(Default)]
 pub struct Fixer {
@@ -12,7 +10,7 @@ impl Fixer {
     pub fn replace_text(&mut self, node: Node, replacement: impl Into<String>) {
         self.pending_fixes
             .get_or_insert_with(Default::default)
-            .push(PendingFix::new(node.byte_range(), replacement.into()));
+            .push(PendingFix::new(node.range(), replacement.into()));
     }
 
     pub(crate) fn into_pending_fixes(self) -> Option<Vec<PendingFix>> {
@@ -25,13 +23,13 @@ impl Fixer {
             .is_none_or_matches(|pending_fixes| pending_fixes.is_empty())
     }
 
-    pub fn remove_range(&mut self, range: ops::Range<usize>) {
+    pub fn remove_range(&mut self, range: Range) {
         self.pending_fixes
             .get_or_insert_with(Default::default)
             .push(PendingFix::new(range, Default::default()));
     }
 
-    pub fn replace_text_range(&mut self, range: ops::Range<usize>, replacement: impl Into<String>) {
+    pub fn replace_text_range(&mut self, range: Range, replacement: impl Into<String>) {
         self.pending_fixes
             .get_or_insert_with(Default::default)
             .push(PendingFix::new(range, replacement.into()));
@@ -46,12 +44,12 @@ impl IsEmpty for Fixer {
 
 #[derive(Clone)]
 pub struct PendingFix {
-    pub range: ops::Range<usize>,
+    pub range: Range,
     pub replacement: String,
 }
 
 impl PendingFix {
-    pub fn new(range: ops::Range<usize>, replacement: String) -> Self {
+    pub fn new(range: Range, replacement: String) -> Self {
         Self { range, replacement }
     }
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -9,7 +9,9 @@ use std::{
 use better_any::TidAble;
 use tracing::{debug, instrument};
 use tree_sitter_grep::{
-    streaming_iterator::StreamingIterator, tree_sitter::Tree, RopeOrSlice, SupportedLanguage,
+    streaming_iterator::StreamingIterator,
+    tree_sitter::{Range, Tree},
+    RopeOrSlice, SupportedLanguage,
 };
 
 mod backward_tokens;
@@ -50,6 +52,7 @@ pub struct FileRunContext<
     pub(crate) query: &'a Arc<Query>,
     pub(crate) instantiated_rules:
         &'a [InstantiatedRule<TFromFileRunContextInstanceProviderFactory>],
+    changed_ranges: Option<&'a [Range]>,
     from_file_run_context_instance_provider:
         &'b TFromFileRunContextInstanceProviderFactory::Provider<'a>,
 }
@@ -78,6 +81,7 @@ impl<
             aggregated_queries: self.aggregated_queries,
             query: self.query,
             instantiated_rules: self.instantiated_rules,
+            changed_ranges: self.changed_ranges,
             from_file_run_context_instance_provider: self.from_file_run_context_instance_provider,
         }
     }
@@ -99,6 +103,7 @@ impl<
         aggregated_queries: &'a AggregatedQueries<TFromFileRunContextInstanceProviderFactory>,
         query: &'a Arc<Query>,
         instantiated_rules: &'a [InstantiatedRule<TFromFileRunContextInstanceProviderFactory>],
+        changed_ranges: Option<&'a [Range]>,
         from_file_run_context_instance_provider: &'b TFromFileRunContextInstanceProviderFactory::Provider<'a>,
     ) -> Self {
         let file_contents = file_contents.into();
@@ -111,6 +116,7 @@ impl<
             aggregated_queries,
             query,
             instantiated_rules,
+            changed_ranges,
             from_file_run_context_instance_provider,
         }
     }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -37,40 +37,22 @@ use crate::{
     AggregatedQueries, Config,
 };
 
-pub struct FileRunContext<
-    'a,
-    'b,
-    TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProviderFactory,
-> {
+pub struct FileRunContext<'a, 'b> {
     pub path: &'a Path,
     pub file_contents: RopeOrSlice<'a>,
     pub tree: &'a Tree,
-    pub config: &'a Config<TFromFileRunContextInstanceProviderFactory>,
+    pub config: &'a Config,
     pub language: SupportedLanguage,
-    pub(crate) aggregated_queries:
-        &'a AggregatedQueries<'a, TFromFileRunContextInstanceProviderFactory>,
+    pub(crate) aggregated_queries: &'a AggregatedQueries<'a>,
     pub(crate) query: &'a Arc<Query>,
-    pub(crate) instantiated_rules:
-        &'a [InstantiatedRule<TFromFileRunContextInstanceProviderFactory>],
+    pub(crate) instantiated_rules: &'a [InstantiatedRule],
     changed_ranges: Option<&'a [Range]>,
-    from_file_run_context_instance_provider:
-        &'b TFromFileRunContextInstanceProviderFactory::Provider<'a>,
+    from_file_run_context_instance_provider: &'b dyn FromFileRunContextInstanceProvider<'a>,
 }
 
-impl<
-        'a,
-        'b,
-        TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProviderFactory,
-    > Copy for FileRunContext<'a, 'b, TFromFileRunContextInstanceProviderFactory>
-{
-}
+impl<'a, 'b> Copy for FileRunContext<'a, 'b> {}
 
-impl<
-        'a,
-        'b,
-        TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProviderFactory,
-    > Clone for FileRunContext<'a, 'b, TFromFileRunContextInstanceProviderFactory>
-{
+impl<'a, 'b> Clone for FileRunContext<'a, 'b> {
     fn clone(&self) -> Self {
         Self {
             path: self.path,
@@ -87,24 +69,19 @@ impl<
     }
 }
 
-impl<
-        'a,
-        'b,
-        TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProviderFactory,
-    > FileRunContext<'a, 'b, TFromFileRunContextInstanceProviderFactory>
-{
+impl<'a, 'b> FileRunContext<'a, 'b> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         path: &'a Path,
         file_contents: impl Into<RopeOrSlice<'a>>,
         tree: &'a Tree,
-        config: &'a Config<TFromFileRunContextInstanceProviderFactory>,
+        config: &'a Config,
         language: SupportedLanguage,
-        aggregated_queries: &'a AggregatedQueries<TFromFileRunContextInstanceProviderFactory>,
+        aggregated_queries: &'a AggregatedQueries,
         query: &'a Arc<Query>,
-        instantiated_rules: &'a [InstantiatedRule<TFromFileRunContextInstanceProviderFactory>],
+        instantiated_rules: &'a [InstantiatedRule],
         changed_ranges: Option<&'a [Range]>,
-        from_file_run_context_instance_provider: &'b TFromFileRunContextInstanceProviderFactory::Provider<'a>,
+        from_file_run_context_instance_provider: &'b dyn FromFileRunContextInstanceProvider<'a>,
     ) -> Self {
         let file_contents = file_contents.into();
         Self {
@@ -122,27 +99,15 @@ impl<
     }
 }
 
-pub struct QueryMatchContext<
-    'a,
-    'b,
-    TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProviderFactory,
-> {
-    pub file_run_context: FileRunContext<'a, 'b, TFromFileRunContextInstanceProviderFactory>,
-    pub(crate) rule: &'a InstantiatedRule<TFromFileRunContextInstanceProviderFactory>,
+pub struct QueryMatchContext<'a, 'b> {
+    pub file_run_context: FileRunContext<'a, 'b>,
+    pub(crate) rule: &'a InstantiatedRule,
     pending_fixes: RefCell<Option<Vec<PendingFix>>>,
     pub(crate) violations: RefCell<Option<Vec<ViolationWithContext>>>,
 }
 
-impl<
-        'a,
-        'b,
-        TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProviderFactory,
-    > QueryMatchContext<'a, 'b, TFromFileRunContextInstanceProviderFactory>
-{
-    pub fn new(
-        file_run_context: FileRunContext<'a, 'b, TFromFileRunContextInstanceProviderFactory>,
-        rule: &'a InstantiatedRule<TFromFileRunContextInstanceProviderFactory>,
-    ) -> Self {
+impl<'a, 'b> QueryMatchContext<'a, 'b> {
+    pub fn new(file_run_context: FileRunContext<'a, 'b>, rule: &'a InstantiatedRule) -> Self {
         Self {
             file_run_context,
             rule,

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -6,7 +6,7 @@ use std::{
     sync::Arc,
 };
 
-use better_any::TidAble;
+use better_any::{TidAble, TidExt};
 use tracing::{debug, instrument};
 use tree_sitter_grep::{
     streaming_iterator::StreamingIterator,
@@ -436,7 +436,9 @@ impl<
     ) -> &TFromFileRunContext {
         self.file_run_context
             .from_file_run_context_instance_provider
-            .get::<TFromFileRunContext>(self.file_run_context)
+            .get(TFromFileRunContext::id(), self.file_run_context)
+            .unwrap()
+            .downcast_ref::<TFromFileRunContext>()
             .unwrap()
     }
 }

--- a/src/context/provided_types.rs
+++ b/src/context/provided_types.rs
@@ -4,26 +4,20 @@ use better_any::{Tid, TidAble};
 
 use crate::FileRunContext;
 
-pub trait FromFileRunContextInstanceProvider<'a>: Sized {
-    type Parent: FromFileRunContextInstanceProviderFactory<Provider<'a> = Self>;
-
+pub trait FromFileRunContextInstanceProvider<'a> {
     fn get(
         &self,
         type_id: TypeId,
-        file_run_context: FileRunContext<'a, '_, Self::Parent>,
+        file_run_context: FileRunContext<'a, '_>,
     ) -> Option<&dyn Tid<'a>>;
 }
 
 pub trait FromFileRunContextInstanceProviderFactory: Send + Sync {
-    type Provider<'a>: FromFileRunContextInstanceProvider<'a, Parent = Self>;
-
-    fn create<'a>(&self) -> Self::Provider<'a>;
+    fn create<'a>(&self) -> Box<dyn FromFileRunContextInstanceProvider<'a> + 'a>;
 }
 
 pub trait FromFileRunContext<'a> {
-    fn from_file_run_context(
-        file_run_context: FileRunContext<'a, '_, impl FromFileRunContextInstanceProviderFactory>,
-    ) -> Self;
+    fn from_file_run_context(file_run_context: FileRunContext<'a, '_>) -> Self;
 }
 
 mod _sealed {
@@ -59,7 +53,7 @@ pub trait FromFileRunContextProvidedTypesOnceLockStorage<'a> {
     fn get(
         &self,
         type_id: TypeId,
-        file_run_context: FileRunContext<'a, '_, impl FromFileRunContextInstanceProviderFactory>,
+        file_run_context: FileRunContext<'a, '_>,
     ) -> Option<&dyn Tid<'a>>;
 }
 
@@ -75,7 +69,7 @@ where
     fn get(
         &self,
         type_id: TypeId,
-        file_run_context: FileRunContext<'a, '_, impl FromFileRunContextInstanceProviderFactory>,
+        file_run_context: FileRunContext<'a, '_>,
     ) -> Option<&dyn Tid<'a>> {
         match self {
             FromFileRunContextProvidedTypesOnceLockStorageEnum::One(t1, _) => match type_id {

--- a/src/context/provided_types.rs
+++ b/src/context/provided_types.rs
@@ -1,16 +1,17 @@
-use std::{marker::PhantomData, mem, sync::OnceLock};
+use std::{any::TypeId, marker::PhantomData, sync::OnceLock};
 
-use better_any::TidAble;
+use better_any::{Tid, TidAble};
 
 use crate::FileRunContext;
 
 pub trait FromFileRunContextInstanceProvider<'a>: Sized {
     type Parent: FromFileRunContextInstanceProviderFactory<Provider<'a> = Self>;
 
-    fn get<T: FromFileRunContext<'a> + TidAble<'a>>(
+    fn get(
         &self,
+        type_id: TypeId,
         file_run_context: FileRunContext<'a, '_, Self::Parent>,
-    ) -> Option<&T>;
+    ) -> Option<&dyn Tid<'a>>;
 }
 
 pub trait FromFileRunContextInstanceProviderFactory: Send + Sync {
@@ -55,11 +56,11 @@ where
 }
 
 pub trait FromFileRunContextProvidedTypesOnceLockStorage<'a> {
-    // fn get<T: FromFileRunContext<'a> + for<'b> TidAble<'b>>(
-    fn get<T: FromFileRunContext<'a> + TidAble<'a>>(
+    fn get(
         &self,
+        type_id: TypeId,
         file_run_context: FileRunContext<'a, '_, impl FromFileRunContextInstanceProviderFactory>,
-    ) -> Option<&T>;
+    ) -> Option<&dyn Tid<'a>>;
 }
 
 pub enum FromFileRunContextProvidedTypesOnceLockStorageEnum<'a, T1> {
@@ -68,23 +69,19 @@ pub enum FromFileRunContextProvidedTypesOnceLockStorageEnum<'a, T1> {
 
 impl<'a, T1> FromFileRunContextProvidedTypesOnceLockStorage<'a>
     for FromFileRunContextProvidedTypesOnceLockStorageEnum<'a, T1>
-// where
-//     T1: FromFileRunContext<'a> + for<'b> TidAble<'b>,
 where
     T1: FromFileRunContext<'a> + TidAble<'a>,
 {
-    // fn get<T: FromFileRunContext<'a> + for<'b> TidAble<'b>>(
-    fn get<T: FromFileRunContext<'a> + TidAble<'a>>(
+    fn get(
         &self,
+        type_id: TypeId,
         file_run_context: FileRunContext<'a, '_, impl FromFileRunContextInstanceProviderFactory>,
-    ) -> Option<&T> {
+    ) -> Option<&dyn Tid<'a>> {
         match self {
-            FromFileRunContextProvidedTypesOnceLockStorageEnum::One(t1, _) => match T::id() {
-                id if id == T1::id() => Some(unsafe {
-                    mem::transmute::<&T1, &T>(
-                        t1.get_or_init(|| T1::from_file_run_context(file_run_context)),
-                    )
-                }),
+            FromFileRunContextProvidedTypesOnceLockStorageEnum::One(t1, _) => match type_id {
+                id if id == T1::id() => {
+                    Some(t1.get_or_init(|| T1::from_file_run_context(file_run_context)))
+                }
                 _ => None,
             },
         }

--- a/src/event_emitter.rs
+++ b/src/event_emitter.rs
@@ -1,0 +1,10 @@
+use tree_sitter_grep::{tree_sitter::Node, SupportedLanguage};
+
+pub type Event = String;
+
+pub trait EventEmitter<'a> {
+    fn name(&self) -> String;
+    fn languages(&self) -> Vec<SupportedLanguage>;
+    fn enter_node(&mut self, node: Node<'a>) -> Option<Vec<Event>>;
+    fn exit_node(&mut self, node: Node<'a>) -> Option<Vec<Event>>;
+}

--- a/src/event_emitter.rs
+++ b/src/event_emitter.rs
@@ -6,5 +6,5 @@ pub trait EventEmitter<'a> {
     fn name(&self) -> String;
     fn languages(&self) -> Vec<SupportedLanguage>;
     fn enter_node(&mut self, node: Node<'a>) -> Option<Vec<Event>>;
-    fn exit_node(&mut self, node: Node<'a>) -> Option<Vec<Event>>;
+    fn leave_node(&mut self, node: Node<'a>) -> Option<Vec<Event>>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod aggregated_queries;
 mod cli;
 mod config;
 mod context;
+mod event_emitter;
 pub mod lsp;
 mod macros;
 mod node;
@@ -13,6 +14,7 @@ mod rule_tester;
 mod slice;
 #[cfg(test)]
 mod tests;
+mod text;
 mod violation;
 
 use std::{
@@ -26,7 +28,6 @@ use std::{
 };
 
 use aggregated_queries::AggregatedQueries;
-pub use better_any::TidAble;
 pub use cli::bootstrap_cli;
 pub use config::{Args, ArgsBuilder, Config, ConfigBuilder, RuleConfiguration};
 use context::PendingFix;
@@ -37,6 +38,7 @@ pub use context::{
     SkipOptionsBuilder,
 };
 use dashmap::DashMap;
+pub use event_emitter::{Event, EventEmitter};
 pub use node::NodeExt;
 pub use plugin::Plugin;
 pub use proc_macros::{builder_args, rule, rule_tests, violation};
@@ -52,6 +54,7 @@ pub use rule_tester::{
 };
 pub use slice::MutRopeOrSlice;
 use squalid::EverythingExt;
+pub use text::SourceTextProvider;
 use tracing::{debug, debug_span, info_span, instrument, trace};
 use tree_sitter::Tree;
 use tree_sitter_grep::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,11 +80,14 @@ pub fn run_and_output<
         process::exit(0);
     }
 
-    let _span = info_span!("printing violations", num_violations = violations.len()).entered();
+    let span = info_span!("printing violations", num_violations = violations.len()).entered();
 
     for violation in violations {
         violation.print(&config);
     }
+
+    span.exit();
+
     process::exit(1);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,7 +268,6 @@ fn run_per_file<
             |pending_fixes, instantiated_rule| {
                 on_found_pending_fixes(pending_fixes, instantiated_rule)
             },
-            false,
         );
     });
 
@@ -315,24 +314,13 @@ fn run_match<
         Vec<PendingFix>,
         &InstantiatedRule<TFromFileRunContextInstanceProviderFactory>,
     ),
-    is_isolated_to_query_subtrees_run: bool,
 ) {
-    let (instantiated_rule, rule_index, rule_listener_index, capture_index_if_per_capture) =
-        file_run_context
-            .aggregated_queries
-            .get_rule_and_listener_index_and_capture_index(
-                file_run_context.language,
-                query_match.pattern_index,
-            );
-
-    if is_isolated_to_query_subtrees_run
-        != file_run_context
-            .aggregated_queries
-            .isolated_to_query_subtrees_instantiated_rules
-            .contains(&rule_index)
-    {
-        return;
-    }
+    let (instantiated_rule, rule_listener_index, capture_index_if_per_capture) = file_run_context
+        .aggregated_queries
+        .get_rule_and_listener_index_and_capture_index(
+            file_run_context.language,
+            query_match.pattern_index,
+        );
 
     trace!(
         rule_name = instantiated_rule.meta.name,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,9 +280,9 @@ fn run_per_file<'a, 'b>(
         );
         return;
     }
-    while !node_stack.is_empty() {
+    while let Some(node) = node_stack.pop() {
         run_exit_node_listeners(
-            node_stack.pop().unwrap(),
+            node,
             file_run_context,
             &mut instantiated_per_file_rules,
             &mut on_found_violations,

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -28,7 +28,7 @@ pub trait LocalLinter: Send + Sync {
     fn run_for_slice<'a>(
         &self,
         file_contents: impl Into<RopeOrSlice<'a>>,
-        tree: Option<&Tree>,
+        tree: Option<Tree>,
         path: impl AsRef<Path>,
         args: Args,
         language: SupportedLanguage,
@@ -37,7 +37,7 @@ pub trait LocalLinter: Send + Sync {
     fn run_fixing_for_slice<'a>(
         &self,
         file_contents: impl Into<MutRopeOrSlice<'a>>,
-        tree: Option<&Tree>,
+        tree: Option<Tree>,
         path: impl AsRef<Path>,
         args: Args,
         language: SupportedLanguage,
@@ -64,7 +64,7 @@ impl<TLocalLinter: LocalLinter> Backend<TLocalLinter> {
         let per_file_state = self.per_file.get(uri).unwrap();
         let violations = self.local_linter.run_for_slice(
             &per_file_state.contents,
-            Some(&per_file_state.tree),
+            Some(per_file_state.tree.clone()),
             "dummy_path",
             Default::default(),
             SupportedLanguage::Rust,
@@ -96,7 +96,7 @@ impl<TLocalLinter: LocalLinter> Backend<TLocalLinter> {
         let mut cloned_contents = per_file_state.contents.clone();
         self.local_linter.run_fixing_for_slice(
             &mut cloned_contents,
-            Some(&per_file_state.tree),
+            Some(per_file_state.tree.clone()),
             "dummy_path",
             ArgsBuilder::default().fix(true).build().unwrap(),
             SupportedLanguage::Rust,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,11 +1,9 @@
 use std::sync::Arc;
 
-use crate::{FromFileRunContextInstanceProviderFactory, Rule};
+use crate::Rule;
 
 #[derive(Clone)]
-pub struct Plugin<
-    TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProviderFactory,
-> {
+pub struct Plugin {
     pub name: String,
-    pub rules: Vec<Arc<dyn Rule<TFromFileRunContextInstanceProviderFactory>>>,
+    pub rules: Vec<Arc<dyn Rule>>,
 }

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -16,6 +16,7 @@ pub struct RuleMeta {
     pub fixable: bool,
     pub languages: Vec<SupportedLanguage>,
     pub messages: Option<HashMap<String, String>>,
+    pub isolated_to_query_subtrees: bool,
 }
 
 pub trait Rule<

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -193,5 +193,3 @@ pub struct ResolvedRuleListenerQuery {
 }
 
 pub type RuleOptions = serde_json::Value;
-
-pub const ROOT_EXIT: &str = "__tree_sitter_lint_program_exit";

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -16,7 +16,6 @@ pub struct RuleMeta {
     pub fixable: bool,
     pub languages: Vec<SupportedLanguage>,
     pub messages: Option<HashMap<String, String>>,
-    pub isolated_to_query_subtrees: bool,
 }
 
 pub trait Rule<

--- a/src/rule_tester.rs
+++ b/src/rule_tester.rs
@@ -180,8 +180,6 @@ fn assert_that_violations_match_expected(
         invalid_test.code
     );
     let mut violations = violations.to_owned();
-    // if https://github.com/tree-sitter/tree-sitter/pull/2460 gets merged then
-    // could restore this to `violations.sort_by_key(|violation| violation.range)`
     violations.sort_by(|a, b| compare_ranges(a.range, b.range));
     for (violation, expected_violation) in iter::zip(violations, &invalid_test.errors) {
         assert_that_violation_matches_expected(&violation, expected_violation, invalid_test);

--- a/src/rule_tester.rs
+++ b/src/rule_tester.rs
@@ -1,6 +1,6 @@
-use std::{cmp::Ordering, iter, marker::PhantomData, sync::Arc};
+use std::{any::TypeId, cmp::Ordering, iter, marker::PhantomData, sync::Arc};
 
-use better_any::TidAble;
+use better_any::Tid;
 use derive_builder::Builder;
 use tree_sitter_grep::{tree_sitter::Range, SupportedLanguage};
 
@@ -9,8 +9,7 @@ use crate::{
     context::FromFileRunContextInstanceProvider,
     rule::{Rule, RuleOptions},
     violation::{MessageOrMessageId, ViolationData, ViolationWithContext},
-    FileRunContext, FromFileRunContext, FromFileRunContextInstanceProviderFactory,
-    RuleConfiguration,
+    FileRunContext, FromFileRunContextInstanceProviderFactory, RuleConfiguration,
 };
 
 pub struct RuleTester<
@@ -383,10 +382,11 @@ pub struct DummyFromFileRunContextInstanceProvider<'a> {
 impl<'a> FromFileRunContextInstanceProvider<'a> for DummyFromFileRunContextInstanceProvider<'a> {
     type Parent = DummyFromFileRunContextInstanceProviderFactory;
 
-    fn get<T: FromFileRunContext<'a> + TidAble<'a>>(
+    fn get(
         &self,
+        _type_id: TypeId,
         _file_run_context: FileRunContext<'a, '_, Self::Parent>,
-    ) -> Option<&T> {
+    ) -> Option<&dyn Tid<'a>> {
         unreachable!()
     }
 }

--- a/src/tests/fixing.rs
+++ b/src/tests/fixing.rs
@@ -7,7 +7,7 @@ use proc_macros::{
     violation_crate_internal as violation,
 };
 
-use crate::{rule::Rule, FromFileRunContextInstanceProviderFactory, RuleTester};
+use crate::{rule::Rule, RuleTester};
 
 #[macro_export]
 macro_rules! assert_fixed_content {
@@ -124,12 +124,10 @@ fn test_multiple_nonconflicting_fixes_from_different_rules() {
     );
 }
 
-fn create_identifier_replacing_rule<
-    TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProviderFactory,
->(
+fn create_identifier_replacing_rule(
     name: impl Into<String>,
     replacement: impl Into<String>,
-) -> Arc<dyn Rule<TFromFileRunContextInstanceProviderFactory>> {
+) -> Arc<dyn Rule> {
     rule! {
         name => format!("replace_{}_with_{}", self.name, self.replacement),
         fixable => true,

--- a/src/tests/rules/mod.rs
+++ b/src/tests/rules/mod.rs
@@ -18,7 +18,7 @@ mod violations;
 
 use crate::{
     rule::Rule, FileRunContext, FromFileRunContext, FromFileRunContextInstanceProvider,
-    FromFileRunContextInstanceProviderFactory, RuleTester, ROOT_EXIT,
+    FromFileRunContextInstanceProviderFactory, RuleTester,
 };
 
 #[test]
@@ -151,7 +151,7 @@ fn test_root_exit_listener() {
         rule! {
             name => "uses-root-exit-listener",
             listeners => [
-                ROOT_EXIT => |node, context| {
+                "source_file:exit" => |node, context| {
                     let mut cursor = node.walk();
                     if node.named_children(&mut cursor).count() != 1 {
                         context.report(violation! {
@@ -195,7 +195,7 @@ fn test_root_exit_listener_amid_other_listeners() {
                         message => "function",
                     });
                 },
-                ROOT_EXIT => |node, context| {
+                "source_file:exit" => |node, context| {
                     let mut cursor = node.walk();
                     if node.named_children(&mut cursor).count() != 1 {
                         context.report(violation! {

--- a/src/tests/rules/state.rs
+++ b/src/tests/rules/state.rs
@@ -6,7 +6,7 @@ use proc_macros::{
 };
 use tree_sitter_grep::tree_sitter::Node;
 
-use crate::{FromFileRunContextInstanceProviderFactory, Rule, RuleTester};
+use crate::{Rule, RuleTester};
 
 #[test]
 fn test_per_file_run_state() {
@@ -39,9 +39,7 @@ fn test_per_file_run_state() {
     );
 }
 
-fn no_more_than_5_uses_of_foo_rule<
-    TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProviderFactory,
->() -> Arc<dyn Rule<TFromFileRunContextInstanceProviderFactory>> {
+fn no_more_than_5_uses_of_foo_rule() -> Arc<dyn Rule> {
     rule! {
         name => "no_more_than_5_uses_of_foo",
         state => {

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,0 +1,26 @@
+use std::{borrow::Cow, ops};
+
+use crate::{tree_sitter::Node, tree_sitter_grep::RopeOrSlice};
+
+pub trait SourceTextProvider<'a> {
+    fn node_text(&self, node: Node) -> Cow<'a, str>;
+}
+
+impl<'a> SourceTextProvider<'a> for &'a [u8] {
+    fn node_text(&self, node: Node) -> Cow<'a, str> {
+        node.utf8_text(self).unwrap().into()
+    }
+}
+
+impl<'a> SourceTextProvider<'a> for RopeOrSlice<'a> {
+    fn node_text(&self, node: Node) -> Cow<'a, str> {
+        get_text_slice(*self, node.byte_range())
+    }
+}
+
+pub fn get_text_slice(file_contents: RopeOrSlice, range: ops::Range<usize>) -> Cow<'_, str> {
+    match file_contents {
+        RopeOrSlice::Slice(slice) => std::str::from_utf8(&slice[range]).unwrap().into(),
+        RopeOrSlice::Rope(rope) => rope.byte_slice(range).into(),
+    }
+}

--- a/src/violation.rs
+++ b/src/violation.rs
@@ -8,7 +8,7 @@ use crate::{
     context::{Fixer, QueryMatchContext},
     rule::RuleMeta,
     tree_sitter::{self, Node},
-    Config, FromFileRunContextInstanceProviderFactory,
+    Config,
 };
 
 #[derive(Builder)]
@@ -38,11 +38,9 @@ impl<'a> fmt::Debug for Violation<'a> {
 }
 
 impl<'a> Violation<'a> {
-    pub fn contextualize<
-        TFromFileRunContextInstanceProviderFactory: FromFileRunContextInstanceProviderFactory,
-    >(
+    pub fn contextualize(
         self,
-        query_match_context: &QueryMatchContext<TFromFileRunContextInstanceProviderFactory>,
+        query_match_context: &QueryMatchContext,
         had_fixes: bool,
     ) -> ViolationWithContext {
         let Violation {
@@ -105,7 +103,7 @@ pub struct ViolationWithContext {
 }
 
 impl ViolationWithContext {
-    pub fn print(&self, config: &Config<impl FromFileRunContextInstanceProviderFactory>) {
+    pub fn print(&self, config: &Config) {
         println!(
             "{:?}:{}:{} {} {}",
             self.path,

--- a/tests/fixtures/tree-sitter-lint-plugin-replace-foo-with/src/lib.rs
+++ b/tests/fixtures/tree-sitter-lint-plugin-replace-foo-with/src/lib.rs
@@ -31,42 +31,6 @@ impl<'a> FromFileRunContext<'a> for Foo<'a> {
 
 tid! { impl<'a> TidAble<'a> for Foo<'a> }
 
-// #[derive(Default)]
-// struct FooProvider<'a> {
-//     foo_instance: OnceLock<Foo<'a>>,
-// }
-
-// impl<'a> FromFileRunContextInstanceProvider<'a> for FooProvider<'a> {
-//     type Parent = FooProviderFactory;
-
-//     fn get<T: FromFileRunContext<'a> + for<'b> TidAble<'b>>(
-//         &self,
-//         file_run_context: FileRunContext<'a, '_, Self::Parent>,
-//     ) -> Option<&T> {
-//         match T::id() {
-//             id if id == Foo::<'a>::id() => Some(unsafe {
-//                 mem::transmute::<&Foo<'a>, &T>(
-//                     self.foo_instance
-//                         .get_or_init(|| Foo::from_file_run_context(file_run_context)),
-//                 )
-//             }),
-//             _ => None,
-//         }
-//     }
-// }
-
-// struct FooProviderFactory;
-
-// impl FromFileRunContextInstanceProviderFactory for FooProviderFactory {
-//     type Provider<'a> = FooProvider<'a>;
-
-//     fn create<'a>(&self) -> Self::Provider<'a> {
-//         FooProvider {
-//             foo_instance: Default::default(),
-//         }
-//     }
-// }
-
 pub fn instantiate<T: FromFileRunContextInstanceProviderFactory>() -> Plugin<T> {
     Plugin {
         name: "replace-foo-with".to_owned(),

--- a/tests/fixtures/tree-sitter-lint-plugin-replace-foo-with/src/lib.rs
+++ b/tests/fixtures/tree-sitter-lint-plugin-replace-foo-with/src/lib.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use tree_sitter_lint::{
     better_any::tid, rule, tree_sitter_grep::RopeOrSlice, violation, FileRunContext,
-    FromFileRunContext, FromFileRunContextInstanceProviderFactory, Plugin, Rule,
+    FromFileRunContext, Plugin, Rule,
 };
 
 // pub type ProvidedTypes<'a> = ();
@@ -15,9 +15,7 @@ pub struct Foo<'a> {
 }
 
 impl<'a> FromFileRunContext<'a> for Foo<'a> {
-    fn from_file_run_context(
-        file_run_context: FileRunContext<'a, '_, impl FromFileRunContextInstanceProviderFactory>,
-    ) -> Self {
+    fn from_file_run_context(file_run_context: FileRunContext<'a, '_>) -> Self {
         Self {
             text: match &file_run_context.file_contents {
                 RopeOrSlice::Slice(file_contents) => {
@@ -31,7 +29,7 @@ impl<'a> FromFileRunContext<'a> for Foo<'a> {
 
 tid! { impl<'a> TidAble<'a> for Foo<'a> }
 
-pub fn instantiate<T: FromFileRunContextInstanceProviderFactory>() -> Plugin<T> {
+pub fn instantiate() -> Plugin {
     Plugin {
         name: "replace-foo-with".to_owned(),
         rules: vec![
@@ -42,7 +40,7 @@ pub fn instantiate<T: FromFileRunContextInstanceProviderFactory>() -> Plugin<T> 
     }
 }
 
-fn replace_foo_with_bar_rule<T: FromFileRunContextInstanceProviderFactory>() -> Arc<dyn Rule<T>> {
+fn replace_foo_with_bar_rule() -> Arc<dyn Rule> {
     rule! {
         name => "replace-foo-with-bar",
         fixable => true,
@@ -65,8 +63,7 @@ fn replace_foo_with_bar_rule<T: FromFileRunContextInstanceProviderFactory>() -> 
     }
 }
 
-fn replace_foo_with_something_rule<T: FromFileRunContextInstanceProviderFactory>(
-) -> Arc<dyn Rule<T>> {
+fn replace_foo_with_something_rule() -> Arc<dyn Rule> {
     rule! {
         name => "replace-foo-with-something",
         fixable => true,
@@ -94,7 +91,7 @@ fn replace_foo_with_something_rule<T: FromFileRunContextInstanceProviderFactory>
     }
 }
 
-fn starts_with_use_rule<T: FromFileRunContextInstanceProviderFactory>() -> Arc<dyn Rule<T>> {
+fn starts_with_use_rule() -> Arc<dyn Rule> {
     rule! {
         name => "starts-with-use",
         listeners => [


### PR DESCRIPTION
In this PR:
- preparing for trying to wire up an "event emitter", remove the `ROOT_EXIT` "special case" listener and allow rules to register "exit" listeners for any node kind

Based on `tracing`