### PR TITLE
Don't re-serialize options

### DIFF
--- a/proc_macros/src/rule.rs
+++ b/proc_macros/src/rule.rs
@@ -524,7 +524,7 @@ fn get_rule_rule_impl(
             if is_option_type(options_type) {
                 quote! {
                     let options: #options_type = options.map(|options| {
-                        #crate_name::serde_json::from_str(&options.to_string()).unwrap_or_else(|_| {
+                        #crate_name::serde_json::from_value(options.clone()).unwrap_or_else(|_| {
                             panic!("Couldn't parse rule options: {:#?}", options.to_string());
                         })
                     });
@@ -537,7 +537,7 @@ fn get_rule_rule_impl(
                 };
                 quote! {
                     let options: #options_type = options.map(|options| {
-                        #crate_name::serde_json::from_str(&options.to_string()).unwrap_or_else(|_| {
+                        #crate_name::serde_json::from_value(options.clone()).unwrap_or_else(|_| {
                             panic!("Couldn't parse rule options: {:#?}", options.to_string());
                         })
                     })#unwrap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -562,12 +562,11 @@ pub fn run_for_slice<'a>(
     if config.fix {
         panic!("Use run_fixing_for_slice()");
     }
-    let instantiated_rules = config.get_instantiated_rules();
     let per_config_context: MaybeOwned<'_, PerConfigContext> = per_config_context.map_or_else(
         || {
             MaybeOwned::Owned(
                 PerConfigContextBuilder {
-                    instantiated_rules,
+                    instantiated_rules: config.get_instantiated_rules(),
                     aggregated_queries_builder: |instantiated_rules| {
                         AggregatedQueries::new(instantiated_rules)
                     },


### PR DESCRIPTION
In this PR:
- don't re-serialize rule options when going from `serde_json::Value` -> specific options type

Fixes #35 

To test:
Looks like eg CLI runs are still working on projects with config files 